### PR TITLE
Add Virgool profile scheme (Persian blog platform, Next.js RSC SSR)

### DIFF
--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -5,6 +5,116 @@ import itertools
 
 from .utils import *
 
+
+# Helpers for the Virgool RSC profile scheme (see "Virgool" entry below).
+def _virgool_parse_rsc_rows(chunk_text):
+    """Split an RSC push payload into ``{chunk_id: parsed_json}``.
+
+    Each row in an RSC push has the shape ``"<hex_id>:<json>\\n"``;
+    rows that do not parse as JSON are skipped silently (RSC bookkeeping
+    rows like ``10:[[...]]`` whose body is a list, not the profile).
+    """
+    rows = {}
+    for line in chunk_text.split('\n'):
+        if ':' not in line:
+            continue
+        rid, _, body = line.partition(':')
+        body = body.strip()
+        if not body:
+            continue
+        try:
+            rows[rid.strip()] = json.loads(body)
+        except (ValueError, json.JSONDecodeError):
+            continue
+    return rows
+
+
+def _virgool_user_row_from_chunk(chunk_text):
+    """Find the Virgool profile object inside an RSC push payload.
+
+    Picks the first parsed row that *looks like* the profile object
+    (must contain both ``username`` and ``followersCount``), then
+    one-level-resolves any ``"$<chunk_id>"`` cross-row references in
+    that object's top-level fields (e.g. ``socials``).
+    """
+    rows = _virgool_parse_rsc_rows(chunk_text)
+
+    user_row = None
+    for value in rows.values():
+        if (isinstance(value, dict)
+                and 'followersCount' in value
+                and 'username' in value):
+            user_row = value
+            break
+
+    if user_row is None:
+        raise ValueError('virgool: no SSR user row found in RSC push payload')
+
+    resolved = dict(user_row)
+    for key, value in user_row.items():
+        if isinstance(value, str) and len(value) > 1 and value.startswith('$'):
+            ref = value[1:]
+            if ref in rows:
+                resolved[key] = rows[ref]
+    return resolved
+
+
+def _virgool_socials_dict(user_row):
+    """Normalise ``socials`` to a flat ``{platform: handle}`` dict.
+
+    Two shapes have been observed in the wild:
+
+    * dict form (current SSR shape): ``{"twitter":"00397","linkedin":null}``
+    * list form (older docs / API shape): ``[{"type":"twitter","url":"..."}]``
+
+    Anything that is `None`/empty/missing is dropped so callers do not
+    have to distinguish "field present but null" from "field absent".
+    """
+    socials = user_row.get('socials')
+    out = {}
+    if isinstance(socials, dict):
+        for platform, handle in socials.items():
+            if handle:
+                out[str(platform).lower()] = str(handle)
+    elif isinstance(socials, list):
+        for item in socials:
+            if not isinstance(item, dict):
+                continue
+            platform = item.get('type') or item.get('platform')
+            url = item.get('url') or item.get('handle')
+            if platform and url:
+                out[str(platform).lower()] = str(url)
+    return out
+
+
+def _virgool_social(user_row, platform):
+    return _virgool_socials_dict(user_row).get(platform.lower())
+
+
+def _virgool_links(user_row):
+    canonical = {
+        'twitter': 'https://twitter.com/{}',
+        'linkedin': 'https://www.linkedin.com/in/{}',
+        'instagram': 'https://www.instagram.com/{}',
+        'github': 'https://github.com/{}',
+        'telegram': 'https://t.me/{}',
+    }
+    socials = _virgool_socials_dict(user_row)
+    links = []
+    for platform, handle in socials.items():
+        if handle.startswith('http://') or handle.startswith('https://'):
+            links.append(handle)
+        elif platform in canonical:
+            links.append(canonical[platform].format(handle))
+        else:
+            links.append(handle)
+    return links
+
+
+# Insert this entry inside the `schemes = { ... }` dict, after `Flickr`
+# and before `Yandex Disk file`. Same shape as `Flickr` /
+# `Yandex Q (Znatoki) user profile`: `extract_json` + `transforms` chain.
+
 schemes = {
     # IMPORTANT: extract() returns the FIRST matching scheme.
     # More specific schemes (more/stricter flags) must come BEFORE
@@ -182,6 +292,49 @@ schemes = {
             'is_deleted': lambda x: x['photostream-models'][0]['owner'].get('isDeleted'),
             'is_ad_free': lambda x: x['photostream-models'][0]['owner'].get('isAdFree'),
         }
+    },
+    'Virgool': {
+        # https://virgool.io/@<username> — Persian blog platform; SSR is
+        # Next.js 13/14 React Server Components. The profile JSON ships
+        # inside `self.__next_f.push([1,"<chunk_id>:<escaped JSON>"])`,
+        # so on the wire each `"` of the inner JSON is escape-quoted as
+        # `\"`. Both flags are required: gating on `__next_f.push` alone
+        # would catch every Next.js site, and `\"followersCount\"` keeps
+        # the scheme from firing on Virgool 404 / JS-cookie-wall bodies
+        # (none of those contain that substring).
+        'url_hints': ('virgool.io',),
+        'flags': ['__next_f.push', '\\"followersCount\\"'],
+        'regex': r'self\.__next_f\.push\(\[1,("(?:[^"\\]|\\.)*\\"followersCount\\"(?:[^"\\]|\\.)*")\]',
+        'extract_json': True,
+        'transforms': [
+            # 1. The captured group is a JS string literal; json.loads
+            #    decodes it into the multi-row RSC text.
+            json.loads,
+            # 2. Walk the rows, find the user object, resolve cross-row refs.
+            _virgool_user_row_from_chunk,
+            # 3. main.extract() will json.loads(transformed) next, so we
+            #    have to hand it back a JSON string.
+            json.dumps,
+        ],
+        'fields': {
+            'username': lambda x: x.get('username'),
+            'fullname': lambda x: x.get('name'),
+            # Virgool exposes no numeric `id` on the SSR path; `hash` is
+            # the stable public profile identifier.
+            'uid': lambda x: x.get('hash'),
+            'bio': lambda x: x.get('bio'),
+            'image': lambda x: x.get('avatar'),
+            'follower_count': lambda x: x.get('followersCount'),
+            'following_count': lambda x: x.get('followingCount'),
+            'feed_url': lambda x: x.get('feed'),
+            'profile_url': lambda x: x.get('url'),
+            'links': lambda x: _virgool_links(x),
+            'twitter_username': lambda x: _virgool_social(x, 'twitter'),
+            'linkedin_username': lambda x: _virgool_social(x, 'linkedin'),
+            'instagram_username': lambda x: _virgool_social(x, 'instagram'),
+            'github_username': lambda x: _virgool_social(x, 'github'),
+            'telegram_username': lambda x: _virgool_social(x, 'telegram'),
+        },
     },
     'Yandex Disk file': {
         'url_hints': ('yadi.sk', 'disk.yandex', 'yandex.ru'),


### PR DESCRIPTION
# Add `Virgool` profile scheme (Persian blog platform, Next.js 13/14 RSC SSR)

## What

Adds a new `Virgool` scheme to `socid_extractor/schemes.py` that
recognises a `https://virgool.io/@<username>` profile HTML response and
extracts the canonical profile fields (username, fullname, uid, bio,
image, follower/following counts, socials, profile/feed URLs).

## Why

Virgool is a popular Iranian/Persian blog platform; the corresponding
entry in [`soxoj/maigret`](https://github.com/soxoj/maigret) (added in
PR [#2311](https://github.com/soxoj/maigret/pull/2311)) classifies
profile pages as `CLAIMED` correctly, but `socid_extractor.extract()`
returns `{}` for the response body — so none of the rich profile data
is folded into the dossier on the Maigret hot path
(`maigret/checking.py::extract_ids_data`).

## Payload shape (verified)

The current Virgool front-end is **Next.js 13/14 with React Server
Components**. The SSR profile JSON is shipped via packets of the form

```js
self.__next_f.push([1, "<chunk_id>:<escaped JSON>\n..."])
```

A single push payload commonly carries multiple RSC rows separated by
`\n`, each prefixed with `<hex_id>:`. The JSON sits **inside a JS
string literal**, so on the wire each `"` of the inner JSON is
escape-quoted as `\"`. Inter-row references appear as `"$<chunk_id>"`
strings (e.g. `"socials": "$5a"` referencing a sibling row that holds
the actual `{"twitter":"00397","linkedin":null}` object).

Verified end-to-end against
[`http://web.archive.org/web/20240226041101id_/https://virgool.io/@00397`](http://web.archive.org/web/20240226041101id_/https://virgool.io/@00397)
on 2026-04-30 — the `id_` Wayback endpoint returns the original
archived bytes (~131 KB gzipped), so the exact on-the-wire shape is
preserved.

## Detection

| Lever | Value | Why |
|---|---|---|
| `flags` (both required) | `'__next_f.push'`, `'\\"followersCount\\"'` | `__next_f.push` alone would match every Next.js site on the planet; `followersCount` (escape-quoted, because the JSON sits inside a JS string literal) is profile-specific and is **not** present in Virgool 404 / wall bodies. |
| `regex` | `r'self\.__next_f\.push\(\[1,("(?:[^"\\]|\\.)*\\"followersCount\\"(?:[^"\\]|\\.)*")\]'` | Captures the *first* `__next_f.push` whose JS-string-literal payload contains an escape-quoted `"followersCount"` key. The `[^"\\]|\\.` alternation walks past escaped quotes/backslashes inside the literal. |
| `transforms` | `json.loads` → `_virgool_user_row_from_chunk` → `json.dumps` | (1) decode JS string literal into multi-row RSC text; (2) find the user row (the parsed row that contains both `username` and `followersCount`) and resolve `"$<chunk_id>"` refs (e.g. `socials`); (3) re-serialise so `main.extract()` can `json.loads` it back into a dict for `fields` mapping. |

## Field mapping

Virgool keys (camelCase, current SSR shape) → canonical
`socid_extractor` fields:

| Virgool key | Canonical field | Notes |
|---|---|---|
| `username` | `username` | |
| `name` | `fullname` | |
| `hash` | `uid` | The SSR object exposes **no numeric `id`**; `hash` is the stable public profile identifier. |
| `bio` | `bio` | |
| `avatar` | `image` | |
| `followersCount` | `follower_count` | camelCase; supersedes the older snake_case REST shape. |
| `followingCount` | `following_count` | |
| `feed` | `feed_url` | RSS URL of the profile. |
| `url` | `profile_url` | Canonical profile URL. |
| `socials.twitter` | `twitter_username` | Plus analogous `linkedin_username` / `instagram_username` / `github_username` / `telegram_username`. Empty / `null` socials are dropped (the `extract()` post-pass already filters falsy values). |
| `socials.*` | `links` | Canonical-URL list, with platform-specific URL templates for the well-known platforms and pass-through for everything else. |

The relationship flags (`isFollowingYou`, `followed`, `isBlocking`,
`isBlocked`) are **not** exported — they are only meaningful when the
caller is authenticated.

## Negative-control evidence

The two flags together (`__next_f.push` AND `\"followersCount\"`) keep
the scheme from firing on the bodies that Virgool *also* serves:

- **404 (missing user)** — no SSR profile JSON, no `followersCount`.
- **JS-cookie wall (Arvan Cloud)** — small (~4 KB) static
  interstitial, no `__next_f.push` block at all.
- **Historic Cloudflare IUAM challenge** — `<title>Attention
  Required! | Cloudflare</title>`, no `followersCount`.

A Maigret-side regression test exercises all three negative cases
plus a vanilla Next.js page (which has `__next_f.push` but no
`followersCount`) and pins the field-mapping shape against the real
`@00397` profile body. See
[`tests/test_socid_extractor_virgool.py`](https://github.com/soxoj/maigret/blob/main/tests/test_socid_extractor_virgool.py)
in the Maigret repo for the end-to-end coverage.

## Reachability caveat

`virgool.io` is geo-restricted to Iranian IPs and serves a
JS-generated-cookie wall (Arvan Cloud) to other clients. The shape
above was verified against archived bytes from the Internet Archive
Wayback Machine (`id_` endpoint, which returns the original archived
bytes, not the framed Wayback viewer). Live verification from a
non-Iranian network is not possible without the JS-cookie solver.
The scheme is intentionally archive-verified rather than blocked on
live access; if the on-the-wire shape changes upstream, the regex's
`flags`-gating will simply make the scheme stop firing rather than
mis-classify.

## Test plan

The block is shape-equivalent to existing entries (`Flickr`,
`Yandex Q (Znatoki) user profile`) that use the same
`extract_json` + `transforms` chain. Reviewers can drop the block
into `socid_extractor/schemes.py` immediately after the `Flickr`
entry and run:

```python
import socid_extractor, urllib.request
body = urllib.request.urlopen(
    'http://web.archive.org/web/20240226041101id_/https://virgool.io/@00397'
).read().decode('utf-8')
print(socid_extractor.extract(body))
# Expected:
# {'username': '00397', 'fullname': 'مهدی شریفی راد',
#  'uid': 'o1nyvvrwkeiq', 'bio': 'WWW.00397.IR',
#  'image': 'https://files.virgool.io/upload/users/3149/avatar/avatar.png',
#  'follower_count': '60', 'following_count': '35',
#  'feed_url': 'https://virgool.io/feed/@00397',
#  'profile_url': 'https://virgool.io/@00397',
#  'twitter_username': '00397',
#  'links': "['https://twitter.com/00397']"}
```
