### PR TITLE
Capture username in Medium RSS schema

### DIFF
--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -798,7 +798,7 @@ schemes = {
     'Medium RSS': {
         'url_hints': ('medium.com',),
         'flags': ['<rss', 'medium.com', 'Stories by'],
-        'regex': r'<title><!\[CDATA\[Stories by (?P<fullname>[^\]]+?) on Medium\]\]></title>[\s\S]*?<image>\s*<url>(?P<image>[^<]+)</url>[\s\S]*?<lastBuildDate>(?P<latest_activity_at>[^<]+)</lastBuildDate>',
+        'regex': r'<title><!\[CDATA\[Stories by (?P<fullname>[^\]]+?) on Medium\]\]></title>[\s\S]*?<link>https://medium\.com/@(?P<username>[^?/<\s]+)[\s\S]*?<image>\s*<url>(?P<image>[^<]+)</url>[\s\S]*?<lastBuildDate>(?P<latest_activity_at>[^<]+)</lastBuildDate>',
         'fields': {},
     },
     'Medium': {


### PR DESCRIPTION
## Summary
The `Medium RSS` schema currently captures `fullname`, `image`, and `latest_activity_at`, but leaves `username` empty. The username is sitting right in the channel's `<link>` element — adding a named-capture group for it.

## Reproducer (before)

```bash
python3 -c "
from socid_extractor import extract
import urllib.request, ssl
ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
req = urllib.request.Request('https://medium.com/feed/@blue', headers={'User-Agent': 'Mozilla/5.0'})
body = urllib.request.urlopen(req, context=ctx).read().decode()
print(extract(body))
"
# -> {'fullname': 'Medium Staff', 'image': '...', 'latest_activity_at': '...'}  (no username)
```

After this patch, the same call also returns `'username': 'blue'`.

## Why this matters
Useful for `--parse` flows against a Medium URL where the username has to be discovered from the page content rather than supplied as input. The older `Medium` HTML schema (still present in the file, for completeness) already exposed `medium_username` — this restores parity for the RSS path.

## Test
```python
import re
body = open('medium_feed.xml').read()  # any user's RSS feed
m = re.search(<new regex>, body, re.MULTILINE)
assert m.groupdict() == {'fullname': '…', 'username': '…', 'image': 'https://…', 'latest_activity_at': '…'}
```