### PR TITLE
fix: LeetCode GraphQL extraction with newer api endpoint query

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -144,7 +144,7 @@
 139 | Product Hunt |  |  |
 140 | Chess.com HTML | [chess_com_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_chess_com_html_e2e) |  |
 141 | Roblox HTML | [roblox_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_roblox_html_e2e) |  |
-142 | LeetCode GraphQL | [leetcode_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_leetcode_graphql_e2e) | LeetCode GraphQL requires POST request |
+142 | LeetCode GraphQL | [leetcode_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_leetcode_graphql_e2e) |  |
 143 | Boosty API | [boosty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_boosty_api_e2e) |  |
 144 | Threads |  |  |
 145 | Smule |  |  |
@@ -158,4 +158,4 @@
 153 | BuyMeACoffee | [buymeacoffee](https://github.com/soxoj/socid-extractor/search?q=test_buymeacoffee) |  |
 154 | Discourse API |  |  |
 
-The table has been updated at 2026-06-01 07:47:37.379241 UTC
+The table has been updated at 2026-06-01 10:57:00.710594 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -2748,6 +2748,12 @@ schemes = {
     },
     'LeetCode GraphQL': {
         'url_hints': ('leetcode.com',),
+        'url_mutations': [
+            {
+                'from': r'https?://leetcode\.com/(?:u/)?(?P<username>[^/]+)/?$',
+                'to': 'https://leetcode.com/graphql?query=query%20userPublicProfile%28%24username%3A%20String%21%29%20%7B%20matchedUser%28username%3A%20%24username%29%20%7B%20username%20profile%20%7B%20realName%20aboutMe%20userAvatar%20countryName%20company%20school%20ranking%20%7D%20%7D%20%7D&variables=%7B%22username%22%3A%20%22{username}%22%7D',
+            }
+        ],
         'flags': ['"data":', '"matchedUser":', '"profile":'],
         'regex': r'^(\{[\s\S]+\})$',
         'extract_json': True,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -650,7 +650,6 @@ def test_eyeem():
     assert info.get('photos') == '3'
     assert info.get('facebook_uid') == '1610716256'
 
-
 @pytest.mark.github_failed
 def test_vimeo_html_e2e():
     """Vimeo HTML"""
@@ -1488,10 +1487,17 @@ def test_stack_exchange_api_e2e():
     assert info.get('created_at') == '1620592473'
 
 
-@pytest.mark.skip(reason='LeetCode GraphQL requires POST request')
 def test_leetcode_graphql_e2e():
     """LeetCode GraphQL"""
-    pass
+    graphql_url = 'https://leetcode.com/graphql?query=query%20userPublicProfile%28%24username%3A%20String%21%29%20%7B%20matchedUser%28username%3A%20%24username%29%20%7B%20username%20profile%20%7B%20realName%20aboutMe%20userAvatar%20countryName%20company%20school%20ranking%20%7D%20%7D%20%7D&variables=%7B%22username%22%3A%20%22votrubac%22%7D'
+
+    info = extract(parse(graphql_url)[0])
+
+    assert info.get('username') == 'votrubac'
+    assert info.get('fullname') == 'Vlad'
+    assert info.get('company') == 'Google'
+    assert info.get('ranking') == '51'
+    assert 'assets.leetcode.com' in info.get('image', '')
 
 
 def test_boosty_api_e2e():


### PR DESCRIPTION
* **Bypassed Cloudflare block on LeetCode:** Standard profile pages throw a `403 Forbidden` due to Cloudflare protection. Switched to fetching user data using the LeetCode GraphQL API endpoint via `GET` requests (using mutations in `schemes.py`).
* **Fixed End-to-End Test:** Unskipped and updated `test_leetcode_graphql_e2e` in `tests/test_e2e.py` to directly fetch and validate user profile fields using the mutated GraphQL query URL.
* **Verified Data Extraction:** Confirmed successful parsing of the username, full name, avatar image URL, country, company, school, and user ranking.
