### PR TITLE
added bio.site

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -164,5 +164,6 @@
 159 | BuyMeACoffee | [buymeacoffee](https://github.com/soxoj/socid-extractor/search?q=test_buymeacoffee) |  |
 160 | Discourse API |  |  |
 161 | Snapchat | [snapchat](https://github.com/soxoj/socid-extractor/search?q=test_snapchat) |  |
+162 | Bio Site | [bio_site](https://github.com/soxoj/socid-extractor/search?q=test_bio_site) |  |
 
-The table has been updated at 2026-07-07 11:34:25.107248 UTC
+The table has been updated at 2026-07-08 12:57:59.495553 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -124,6 +124,37 @@ def _gh_handle_for(accounts, provider):
     return None
 
 
+def _bio_site_section(profile, section_type):
+    for item in profile.get('body') or []:
+        if item.get('type') == section_type:
+            return item.get('section') or {}
+    return {}
+
+
+def _bio_site_social_handles(profile):
+    return _bio_site_section(profile, 'section_social').get('handles') or []
+
+
+def _bio_site_links(profile):
+    urls = []
+    for handle in _bio_site_social_handles(profile):
+        if handle.get('url'):
+            urls.append(handle.get('url'))
+
+    links_section = _bio_site_section(profile, 'section_links')
+    for link in links_section.get('links') or []:
+        if link.get('url'):
+            urls.append(link.get('url'))
+    return urls
+
+
+def _bio_site_social_value(profile, provider):
+    for handle in _bio_site_social_handles(profile):
+        if handle.get('type') == provider:
+            return handle.get('value')
+    return None
+
+
 schemes = {
     # IMPORTANT: extract() returns the FIRST matching scheme.
     # More specific schemes (more/stricter flags) must come BEFORE
@@ -3218,6 +3249,24 @@ schemes = {
             'snapcode_image': lambda x: x['userProfile']['userInfo'].get('snapcodeImageUrl'),
             'profile_type': lambda x: x['userProfile'].get('$case'),
         }
+    },
+    'Bio Site': {
+        'url_hints': ('bio.site',),
+        'flags': ['window.initial_state=', 'media.bio.site', 'Bio Sites'],
+        'regex': r'window\.initial_state=({[\s\S]+?});\s*window\.additionalRenderingContext=',
+        'extract_json': True,
+        'fields': {
+            'uid': lambda x: x.get('id'),
+            'username': lambda x: x.get('metadata', {}).get('handle'),
+            'fullname': lambda x: x.get('header', {}).get('name'),
+            'bio': lambda x: x.get('header', {}).get('bio'),
+            'image': lambda x: x.get('header', {}).get('profile_photo'),
+            'image_bg': lambda x: x.get('header', {}).get('cover_photo'),
+            'created_at': lambda x: parse_datetime(x.get('metadata', {}).get('created_at')),
+            'updated_at': lambda x: parse_datetime(x.get('metadata', {}).get('last_updated_at')),
+            'links': _bio_site_links,
+            'instagram_username': lambda x: _bio_site_social_value(x, 'instagram'),
+        },
     },
 }
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1618,3 +1618,21 @@ def test_snapchat():
     assert info.get(
         'snapcode_image') == 'https://app.snapchat.com/web/deeplink/snapcode?username=ogovorka&type=SVG&bitmoji=enable'
     assert info.get('profile_type') == 'userInfo'
+
+
+def test_bio_site():
+    """Bio Site"""
+    info = extract(parse('https://bio.site/Fish')[0])
+
+    assert info.get('uid') == '900C1C86-7397-438A-A4BB-D5201C13A943'
+    assert info.get('username') == 'Fish'
+    assert info.get('fullname') == 'F.B_Studio'
+    assert info.get('bio') == '-\n平價男女裝｜飾品｜生活小物 \n𝐹𝑖𝑠ℎ.𝑏𝑎𝑒 𝑠𝑡𝑢𝑑𝑖𝑜 ✔︎\n'
+    assert info.get('image') == 'https://media.bio.site/sites/7pQNVV5qXgtSrGyhMQd8eY/qYkypfu4hmxAKnufxJqfQc.png'
+    assert info.get('image_bg') == 'https://media.bio.site/sites/7pQNVV5qXgtSrGyhMQd8eY/oqtWruzh467NWyWAJEbjRf.png'
+    assert info.get('created_at') == '2022-03-03 09:24:42 UTC'
+    assert info.get('updated_at') == '2022-10-16 11:59:42 UTC'
+    assert info.get('instagram_username') == 'fish_bae148'
+    assert 'https://www.instagram.com/fish_bae148' in info.get('links')
+    assert 'https://shopee.tw/kissyoumybaby' in info.get('links')
+    assert 'social_links' not in info


### PR DESCRIPTION
tests have passed

logs:
```
❱ pytest tests/test_e2e.py::test_bio_site -v
========================================================== test session starts ==========================================================
platform linux -- Python 3.14.5, pytest-9.1.1, pluggy-1.6.0 -- /home/ayx/downloads/git/test/socid-extractor/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ayx/downloads/git/test/socid-extractor
configfile: pyproject.toml
collected 1 item                                                                                                                        

tests/test_e2e.py::test_bio_site PASSED                                                                                           [100%]

=========================================================== warnings summary ============================================================
venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464
  /home/ayx/downloads/git/test/socid-extractor/venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 1 passed, 1 warning in 0.26s ======================================================
```