### PR TITLE
Added Faceit

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -165,5 +165,6 @@
 160 | Discourse API |  |  |
 161 | Snapchat | [snapchat](https://github.com/soxoj/socid-extractor/search?q=test_snapchat) |  |
 162 | Bio Site | [bio_site](https://github.com/soxoj/socid-extractor/search?q=test_bio_site) |  |
+163 | Faceit API | [faceit_api](https://github.com/soxoj/socid-extractor/search?q=test_faceit_api) |  |
 
-The table has been updated at 2026-07-08 12:57:59.495553 UTC
+The table has been updated at 2026-07-10 10:00:54.075089 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -155,6 +155,26 @@ def _bio_site_social_value(profile, provider):
     return None
 
 
+def _faceit_current_game(profile):
+    games = profile.get('games') or {}
+    game_key = profile.get('flag')
+    if game_key and isinstance(games.get(game_key), dict):
+        return games[game_key]
+    for game in games.values():
+        if isinstance(game, dict):
+            return game
+    return {}
+
+
+def _faceit_streaming_links(profile):
+    streaming = profile.get('streaming') or {}
+    links = {}
+    for platform, handle in streaming.items():
+        if handle:
+            links[platform.removesuffix('_id')] = handle
+    return links
+
+
 schemes = {
     # IMPORTANT: extract() returns the FIRST matching scheme.
     # More specific schemes (more/stricter flags) must come BEFORE
@@ -3266,6 +3286,39 @@ schemes = {
             'updated_at': lambda x: parse_datetime(x.get('metadata', {}).get('last_updated_at')),
             'links': _bio_site_links,
             'instagram_username': lambda x: _bio_site_social_value(x, 'instagram'),
+        },
+    },
+    'Faceit API': {
+        'url_hints': ('faceit.com',),
+        'flags': ['"payload"', '"skill_level_label"' ,'"registration_status_v2"'],
+        'regex': r'^({[\S\s]+})$',
+        'extract_json': True,
+        'transforms': [
+            json.loads,
+            lambda x: x.get('payload') or {},
+            json.dumps,
+        ],
+        'url_mutations': [
+            {
+                'from': r'https?://(?:www\.)?faceit\.com/(?:[a-z]{2}/)?players/(?P<username>[^/?#]+).*',
+                'to': 'https://www.faceit.com/api/users/v1/nicknames/{username}',
+            },
+        ],
+        'fields': {
+            'uid': lambda x: x.get('id'),
+            'username': lambda x: x.get('nickname'),
+            'image': lambda x: x.get('avatar'),
+            'image_bg': lambda x: x.get('cover_image_url'),
+            'country_code': lambda x: x.get('country', '').upper() if x.get('country') else None,
+            'created_at': lambda x: parse_datetime_str(x.get('created_at')) if x.get('created_at') else None,
+            'friends_count': lambda x: len(x.get('friends') or []),
+            'faceit_game': lambda x: x.get('flag'),
+            'faceit_elo': lambda x: _faceit_current_game(x).get('faceit_elo'),
+            'faceit_skill_level': lambda x: _faceit_current_game(x).get('skill_level'),
+            'faceit_region': lambda x: _faceit_current_game(x).get('region'),
+            'steam_id': lambda x: x.get('platforms', {}).get('steam', {}).get('id64'),
+            'steam_nickname': lambda x: x.get('platforms', {}).get('steam', {}).get('nickname'),
+            'social_links': lambda x: _faceit_streaming_links(x),
         },
     },
 }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1636,3 +1636,23 @@ def test_bio_site():
     assert 'https://www.instagram.com/fish_bae148' in info.get('links')
     assert 'https://shopee.tw/kissyoumybaby' in info.get('links')
     assert 'social_links' not in info
+
+
+def test_faceit_api():
+    """Faceit API"""
+    info = extract(parse('https://www.faceit.com/api/users/v1/nicknames/simple')[0])
+
+    assert info.get('uid') == 'c55fb0f8-e3d9-4fc0-b3fa-f2878513e588'
+    assert info.get('username') == 'simple'
+    assert info.get('country_code') == 'BJ'
+    assert info.get('created_at') == '2018-08-02 10:46:27.703000+00:00'
+    assert info.get('friends_count', '').isdigit()
+    assert info.get('faceit_game') == 'cs2'
+    assert info.get('faceit_region') == 'EU'
+    assert info.get('faceit_elo', '').isdigit()
+    assert info.get('faceit_skill_level', '').isdigit()
+    assert info.get('steam_id') == '76561198838222710'
+    assert info.get('steam_nickname') == 'kr1pton'
+    assert info.get('social_links') == "{'twitch': 'umarooff'}"
+    assert 'faceit-cdn.net' in info.get('image', '')
+    assert 'faceit-cdn.net' in info.get('image_bg', '')


### PR DESCRIPTION
tests have passed

logs:

```
❱ pytest tests/test_e2e.py::test_faceit_api -v
===================================================================================== test session starts ======================================================================================
platform linux -- Python 3.14.5, pytest-9.1.1, pluggy-1.6.0 -- /home/ayx/downloads/git/test/socid-extractor/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ayx/downloads/git/test/socid-extractor
configfile: pyproject.toml
collected 1 item                                                                                                                                                                               

tests/test_e2e.py::test_faceit_api PASSED                                                                                                                                                [100%]

======================================================================================= warnings summary =======================================================================================
venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464
  /home/ayx/downloads/git/test/socid-extractor/venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 1 passed, 1 warning in 0.33s =================================================================================
```