### PR TITLE
Extend Instagram GraphQL scheme with bio links, tagged usernames, post count

### DIFF
--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -882,6 +882,15 @@ schemes = {
             'is_verified': lambda x: x.get('is_verified'),
             'follower_count': lambda x: (x.get('edge_followed_by') or {}).get('count'),
             'following_count': lambda x: (x.get('edge_follow') or {}).get('count'),
+            'post_count': lambda x: (x.get('edge_owner_to_timeline_media') or {}).get('count'),
+            'links': lambda x: [
+                link['url'] for link in (x.get('bio_links') or []) if link.get('url')
+            ] or None,
+            'usernames': lambda x: [
+                entity['user']['username']
+                for entity in ((x.get('biography_with_entities') or {}).get('entities') or [])
+                if (entity.get('user') or {}).get('username')
+            ] or None,
         }
     },
     'Spotify API': {

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import json
+
 import pytest
 
 from socid_extractor.activation import get_twitter_headers
@@ -1603,6 +1605,43 @@ def test_instagram_graphql_e2e():
     assert info.get('is_private') == 'False'
     assert info.get('is_verified') == 'True'
     assert int(info.get('follower_count', 0)) > 500000000
+
+
+def test_instagram_graphql_bio_links_and_tagged_usernames():
+    """Instagram GraphQL: bio_links, tagged usernames, post_count"""
+    body = json.dumps({
+        'data': {
+            'user': {
+                'username': 'ronaldinho',
+                'full_name': 'Ronaldinho Gaúcho',
+                'biography': 'Instagram oficial de Ronaldinho Gaúcho.\n@tropadobruxo_',
+                'bio_links': [{'url': 'https://r10score.net/ronaldinho'}],
+                'biography_with_entities': {
+                    'entities': [
+                        {'user': {'username': 'tropadobruxo_'}},
+                        {'hashtag': 'melhor'},
+                    ]
+                },
+                'edge_followed_by': {'count': 80107703},
+                'edge_follow': {'count': 600},
+                'edge_owner_to_timeline_media': {'count': 3200},
+                'is_verified': True,
+                'is_private': False,
+                'profile_pic_url_hd': 'https://example.com/pic.jpg',
+            }
+        }
+    })
+
+    info = extract(body)
+
+    assert info.get('username') == 'ronaldinho'
+    assert info.get('fullname') == 'Ronaldinho Gaúcho'
+    assert 'tropadobruxo_' in info.get('bio')
+    assert info.get('links') == "['https://r10score.net/ronaldinho']"
+    assert info.get('usernames') == "['tropadobruxo_']"
+    assert info.get('post_count') == '3200'
+    assert info.get('follower_count') == '80107703'
+    assert info.get('following_count') == '600'
 
 
 def test_snapchat():


### PR DESCRIPTION
## Context

soxoj/maigret#2848 reported that `socid_extractor.extract()` returns `{}` for Instagram's `web_profile_info` API response — no bio, links, or tagged usernames extracted despite a fully populated JSON response — and added a maigret-side fallback parser to work around it.

## Root cause

That maigret PR predates the `Instagram GraphQL` scheme added here in #253, which already matches this exact response shape (`data.user`, flagged on `"biography"`/`"edge_followed_by"`/`"profile_pic_url_hd"`). The scheme just didn't extract `bio_links`, tagged usernames from `biography_with_entities`, or the post count.

## Fix

Extend the existing `Instagram GraphQL` scheme (`socid_extractor/schemes.py`) with:
- `links` — URLs from `bio_links`
- `usernames` — tagged usernames from `biography_with_entities.entities`
- `post_count` — from `edge_owner_to_timeline_media`

No new scheme needed; upgrading `socid_extractor` should let maigret drop its fallback.

## Test plan
- [x] Added `test_instagram_graphql_bio_links_and_tagged_usernames` (synthetic fixture, no network) covering the new fields
- [x] `pytest tests/ -m "not github_failed and not rate_limited"` passes (pre-existing unrelated failures: cookie fixture paths, snapchat encoding)