### PR TITLE
feat: add HuggingFace API extraction scheme to support profile parsing

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -176,5 +176,6 @@
 171 | Matrix profile API |  |  |
 172 | osu! | [osu](https://github.com/soxoj/socid-extractor/search?q=test_osu) |  |
 173 | Lens (Hey/Orb/Buttrfly) account | [lens_account](https://github.com/soxoj/socid-extractor/search?q=test_lens_account), [lens_account_absent](https://github.com/soxoj/socid-extractor/search?q=test_lens_account_absent) |  |
+174 | HuggingFace API | [huggingface_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_huggingface_api_e2e) |  |
 
-The table has been updated at 2026-08-02 15:54:35.116398 UTC
+The table has been updated at 2026-08-11 15:26:18.203756 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -3649,6 +3649,24 @@ schemes = {
             'created_at':       lambda x: parse_datetime_str(x['createdAt']) if x.get('createdAt') else None,
         },
     },
+    'HuggingFace API': {
+        'url_hints': ('huggingface.co',),
+        'flags': ['"numModels":', '"numDatasets":', '"numSpaces":'],
+        'regex': r'^(\{[\s\S]+\})$',
+        'extract_json': True,
+        'fields': {
+            'username': lambda x: x.get('user'),
+            'fullname': lambda x: x.get('fullname') or None,
+            'bio': lambda x: x.get('details') or None,
+            'image': lambda x: x.get('avatarUrl') if x.get('avatarUrl') and x.get('avatarUrl').startswith('http') else ('https://huggingface.co' + x.get('avatarUrl') if x.get('avatarUrl') else None),
+            'follower_count': lambda x: x.get('numFollowers'),
+            'following_count': lambda x: x.get('numFollowing'),
+            'created_at': lambda x: x.get('createdAt'),
+            'huggingface_models': lambda x: x.get('numModels'),
+            'huggingface_datasets': lambda x: x.get('numDatasets'),
+            'huggingface_spaces': lambda x: x.get('numSpaces'),
+        }
+    },
 }
 
 # -- Plugin loading (must come after the built-in schemes dict is defined) --

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1690,3 +1690,18 @@ def test_lens_account_absent():
     """Lens (Hey/Orb/Buttrfly) account"""
     # Missing account -> {"data":{"account":null}}; scheme must not fire.
     assert extract('{"data":{"account":null}}') == {}
+def test_huggingface_api_e2e():
+    """HuggingFace API"""
+    info = extract(parse('https://huggingface.co/api/users/julien-c/overview')[0])
+
+    assert info.get('username') == 'julien-c'
+    assert info.get('fullname')
+    assert info.get('bio')
+    assert info.get('created_at')
+    assert 'cdn-avatars.huggingface.co' in info.get('image', '')
+    assert int(info.get('huggingface_models', -1)) >= 0
+    assert int(info.get('huggingface_datasets', -1)) >= 0
+    assert int(info.get('huggingface_spaces', -1)) >= 0
+    assert int(info.get('follower_count', -1)) > 0
+    assert int(info.get('following_count', -1)) >= 0
+


### PR DESCRIPTION
* Introduces a new extraction scheme for `HuggingFace API` in `socid_extractor/schemes.py`.
* Maps the API response to standard fields including `username`, `fullname`, `bio`, `created_at`, `follower_count`, and `following_count`.
* Adds platform-specific extraction fields for `huggingface_models`, `huggingface_datasets`, and `huggingface_spaces`.
* Implements robust avatar extraction handling both relative CDN paths and absolute URLs.
* Includes a comprehensive end-to-end test in `test_e2e.py` validating the extraction logic against a live profile.
* Regenerates `METHODS.md` to reflect the newly supported extraction method.