### PR TITLE
feat: update HackerNews extraction to avoid API timeout and use HTML parsing

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -177,5 +177,6 @@
 172 | osu! | [osu](https://github.com/soxoj/socid-extractor/search?q=test_osu) |  |
 173 | Lens (Hey/Orb/Buttrfly) account | [lens_account](https://github.com/soxoj/socid-extractor/search?q=test_lens_account), [lens_account_absent](https://github.com/soxoj/socid-extractor/search?q=test_lens_account_absent) |  |
 174 | HuggingFace API | [huggingface_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_huggingface_api_e2e) |  |
+175 | HackerNews | [hackernews](https://github.com/soxoj/socid-extractor/search?q=test_hackernews) |  |
 
-The table has been updated at 2026-08-11 15:26:18.203756 UTC
+The table has been updated at 2026-08-17 23:58:44.131716 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -3667,6 +3667,17 @@ schemes = {
             'huggingface_spaces': lambda x: x.get('numSpaces'),
         }
     },
+    'HackerNews': {
+        'url_hints': ('news.ycombinator.com',),
+        'flags': ['>created:</td>', '>karma:</td>'],
+        'regex': r'^([\s\S]+)$',
+        'fields': {
+            'username': lambda x: m.group(1) if (m := re.search(r'class="hnuser">([^<]+)</a>', x)) else None,
+            'created_at': lambda x: m.group(1).strip() if (m := re.search(r'created:</td><td><span class="age"><a[^>]+>([^<]+)</a></span></td>', x)) else (m2.group(1).strip() if (m2 := re.search(r'created:</td><td>([^<]+)</td>', x)) else None),
+            'karma': lambda x: int(re.sub(r'[^\d]', '', m.group(1))) if (m := re.search(r'karma:</td><td>([^<]+)</td>', x)) and re.sub(r'[^\d]', '', m.group(1)) else None,
+            'bio': lambda x: re.sub(r'<[^>]+>', '', m.group(1)).strip() if (m := re.search(r'about:</td><td[^>]*>(.*?)</td>', x, re.DOTALL)) else None,
+        }
+    },
 }
 
 # -- Plugin loading (must come after the built-in schemes dict is defined) --

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1705,3 +1705,13 @@ def test_huggingface_api_e2e():
     assert int(info.get('follower_count', -1)) > 0
     assert int(info.get('following_count', -1)) >= 0
 
+
+def test_hackernews():
+    """HackerNews"""
+    html = '<tr class="athing"><td valign="top">user:</td><td timestamp="1160418092"><a href="user?id=pg" class="hnuser">pg</a></td></tr><tr><td valign="top">created:</td><td><span class="age"><a href="front?day=2006-10-09&birth=pg">October 9, 2006</a></span></td></tr><tr><td valign="top">karma:</td><td>157316</td></tr><tr><td valign="top">about:</td><td style="overflow:hidden">Bug fixer.</td></tr>'
+    info = extract(html)
+
+    assert info.get('username') == 'pg'
+    assert '2006' in info.get('created_at', '')
+    assert int(info.get('karma', -1)) > 100000
+    assert info.get('bio') == 'Bug fixer.'


### PR DESCRIPTION
* Add a new HackerNews extraction scheme to parse user profiles via HTML.
* Extract profile metadata including username, account creation date, karma, and bio.
* Transition away from Firebase API usage to prevent payload size timeouts for highly active users.
* Add end-to-end tests for HackerNews extraction.
* Update METHODS.md to reflect the new scheme capabilities.