### PR TITLE
Discourse: one scheme for every instance, not a list of hosts

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -164,7 +164,7 @@
 159 | DBLP person record |  |  |
 160 | Scholia author profile |  |  |
 161 | BuyMeACoffee | [buymeacoffee](https://github.com/soxoj/socid-extractor/search?q=test_buymeacoffee) |  |
-162 | Discourse API |  |  |
+162 | Discourse API | [discourse_api](https://github.com/soxoj/socid-extractor/search?q=test_discourse_api) |  |
 163 | Snapchat | [snapchat](https://github.com/soxoj/socid-extractor/search?q=test_snapchat) |  |
 164 | Bio Site | [bio_site](https://github.com/soxoj/socid-extractor/search?q=test_bio_site) |  |
 165 | Faceit API | [faceit_api](https://github.com/soxoj/socid-extractor/search?q=test_faceit_api) |  |
@@ -215,56 +215,55 @@
 210 | Poe.com profile |  |  |
 211 | Gumroad profile |  |  |
 212 | Mastodon HTML profile |  |  |
-213 | Discourse HTML profile |  |  |
+213 | Discourse HTML profile | [discourse_html_profile](https://github.com/soxoj/socid-extractor/search?q=test_discourse_html_profile) |  |
 214 | Mastodon API |  |  |
-215 | Discourse Forums |  |  |
-216 | FL.ru |  |  |
-217 | Manifold Markets |  |  |
-218 | VSCO |  |  |
-219 | Mojang API |  |  |
-220 | OP.GG |  |  |
-221 | coder.social |  |  |
-222 | GOG |  |  |
-223 | Kick API |  |  |
-224 | Academia.edu |  |  |
-225 | TradingView |  |  |
-226 | Geocaching |  |  |
-227 | Rutracker |  |  |
-228 | Weburg |  |  |
-229 | Pokemon Showdown |  |  |
-230 | ImageShack |  |  |
-231 | Replit |  |  |
-232 | Itch.io |  |  |
-233 | Giphy |  |  |
-234 | Wattpad HTML profile |  |  |
-235 | Venmo |  |  |
-236 | Tumblr blog |  |  |
-237 | Drive2.ru |  |  |
-238 | Lichess API |  |  |
-239 | Hackerrank API |  |  |
-240 | Kongregate API |  |  |
-241 | WordPress.com site API |  |  |
-242 | Codecademy profile |  |  |
-243 | About.me profile |  |  |
-244 | Fur Affinity profile |  |  |
-245 | Pikabu profile |  |  |
-246 | Codepen profile |  |  |
-247 | Letterboxd profile |  |  |
-248 | Gitee profile |  |  |
-249 | Slack workspace |  |  |
-250 | Instructables member |  |  |
-251 | Envato Author profile |  |  |
-252 | Kwork freelancer |  |  |
-253 | Freesound user |  |  |
-254 | Star Citizen citizen |  |  |
-255 | Dribbble profile |  |  |
-256 | Depop shop |  |  |
-257 | ModDB member |  |  |
-258 | Xbox Gamertag |  |  |
-259 | DonationAlerts streamer |  |  |
-260 | CCM profile |  |  |
-261 | Wikidot user |  |  |
-262 | Couchsurfing person |  |  |
-263 | ReverbNation artist |  |  |
+215 | FL.ru |  |  |
+216 | Manifold Markets |  |  |
+217 | VSCO |  |  |
+218 | Mojang API |  |  |
+219 | OP.GG |  |  |
+220 | coder.social |  |  |
+221 | GOG |  |  |
+222 | Kick API |  |  |
+223 | Academia.edu |  |  |
+224 | TradingView |  |  |
+225 | Geocaching |  |  |
+226 | Rutracker |  |  |
+227 | Weburg |  |  |
+228 | Pokemon Showdown |  |  |
+229 | ImageShack |  |  |
+230 | Replit |  |  |
+231 | Itch.io |  |  |
+232 | Giphy |  |  |
+233 | Wattpad HTML profile |  |  |
+234 | Venmo |  |  |
+235 | Tumblr blog |  |  |
+236 | Drive2.ru |  |  |
+237 | Lichess API |  |  |
+238 | Hackerrank API |  |  |
+239 | Kongregate API |  |  |
+240 | WordPress.com site API |  |  |
+241 | Codecademy profile |  |  |
+242 | About.me profile |  |  |
+243 | Fur Affinity profile |  |  |
+244 | Pikabu profile |  |  |
+245 | Codepen profile |  |  |
+246 | Letterboxd profile |  |  |
+247 | Gitee profile |  |  |
+248 | Slack workspace |  |  |
+249 | Instructables member |  |  |
+250 | Envato Author profile |  |  |
+251 | Kwork freelancer |  |  |
+252 | Freesound user |  |  |
+253 | Star Citizen citizen |  |  |
+254 | Dribbble profile |  |  |
+255 | Depop shop |  |  |
+256 | ModDB member |  |  |
+257 | Xbox Gamertag |  |  |
+258 | DonationAlerts streamer |  |  |
+259 | CCM profile |  |  |
+260 | Wikidot user |  |  |
+261 | Couchsurfing person |  |  |
+262 | ReverbNation artist |  |  |
 
-The table has been updated at 2026-09-06 16:23:52.636011 UTC
+The table has been updated at 2026-09-06 17:32:40.442453 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -252,35 +252,41 @@ def _search_group(pattern, text, group=1):
     match = re.search(pattern, text or '')
     return match.group(group) if match else None
 
-def _discourse_user_field(soup, field):
-    """Extract a field from Discourse data-preloaded user JSON embedded in HTML.
+def _discourse_html_profile(page):
+    """Pull what a Discourse profile page still carries in its server-rendered HTML.
 
-    Falls back to <title> for username when user data is missing
-    (e.g. on /summary pages where Discourse doesn't embed user JSON).
+    Modern Discourse draws the profile on the client — everything lives in the JSON
+    at /u/<name>.json, which the url_mutation below fetches. The HTML shell is worth
+    parsing anyway: it names the user in the avatar URL and carries the bio in
+    og:description, which is all one gets when an instance closes its API. There is
+    no user id in it.
     """
-    tag = soup.find(id='data-preloaded')
-    if tag and tag.get('data-preloaded'):
-        raw = tag['data-preloaded']
-        m = re.search(r'"user_\w+":"(.*?)"(?:,"|\}$)', raw)
-        if m:
-            inner = m.group(1).replace('\\"', '"')
-            try:
-                data = json.loads(inner)
-            except (json.JSONDecodeError, ValueError):
-                data = {}
-            user = data.get('user', {})
-            val = user.get(field)
-            if val is not None:
-                return val
+    def find(pattern):
+        match = re.search(pattern, page)
+        return html.unescape(match.group(1)) if match else None
 
-    # Fallback: extract username from <title>Profile - {username} - {site}</title>
-    if field == 'username':
-        title_tag = soup.find('title')
-        if title_tag and title_tag.string:
-            tm = re.match(r'\s*Profile\s*-\s*(.+?)\s*-\s*', title_tag.string)
-            if tm:
-                return tm.group(1)
-    return None
+    # Every page of a forum carries the generator tag and other people's avatars,
+    # so the profile has to be identified before anything is read off it —
+    # otherwise a topic page would report whoever posted in it first.
+    # The canonical link keeps the sub-route (/u/<name>/summary), which is how
+    # maigret stores these accounts, so the name is read without anchoring the end.
+    username = find(r'<link rel="canonical" href="[^"]*/u/([^"/?#]+)')
+    if not username and re.search(r'<title>\s*Profile - ', page):
+        username = find(r'/user_avatar/[^/"]+/([^/"]+)/')
+    if not username:
+        return '{}'
+
+    bio = find(r'property="og:description" content="([^"]*)"')
+    image = find(r'property="og:image" content="([^"]+)"')
+    # The canonical link is on the deny page too, so a username on its own is just
+    # the request echoed back — instances that refuse anonymous profiles would
+    # otherwise "confirm" every name asked about. Something the account owns has
+    # to come with it.
+    if not (bio or image):
+        return '{}'
+
+    return json.dumps({'username': username, 'bio': bio, 'image': image})
+
 
 def _fl_ld(soup, *keys):
     """Extract a nested value from FL.ru JSON-LD (application/ld+json)."""
@@ -364,49 +370,6 @@ _MASTODON_INSTANCES = [
     'social.bund.de',
     'toot.cat',
     'infosec.exchange',
-]
-
-_DISCOURSE_INSTANCES = [
-    'community.openai.com',
-    'blenderartists.org',
-    'discourse.flathub.org',
-    'discussions.unity.com',
-    'forums.unrealengine.com',
-    'community.shopify.com',
-    'community.plotly.com',
-    'discuss.streamlit.io',
-    'forums.meteor.com',
-    'forums.eveonline.com',
-    'forums.comodo.com',
-    'discuss.kde.org',
-    'discuss.rubyonrails.org',
-    'discuss.ai.google.dev',
-    'discussion.fedoraproject.org',
-    'twittercommunity.com',
-    'forums.spongepowered.org',
-    'community.e.foundation',
-    'community.netdata.cloud',
-    'community.norton.com',
-    'community.trading212.com',
-    'community.humanetech.com',
-    'forum.djangoproject.com',
-    'forum.crystal-lang.org',
-    'forum.dfinity.org',
-    'forum.hackthebox.com',
-    'forums.powershell.org',
-    'forum.polkadot.network',
-    'forum.modular.com',
-    'forum.shopware.com',
-    'internals.rust-lang.org',
-    'krita-artists.org',
-    'root-forum.cern.ch',
-    'erlangforums.com',
-    'tosdr.community',
-    'ziggit.dev',
-    'community.bunpro.jp',
-    'discuss.ray.io',
-    'forum.jscourse.com',
-    'forum.valuepickr.com',
 ]
 
 
@@ -3524,6 +3487,18 @@ schemes = {
             'created_at': lambda x: x.get('created_at'),
             'latest_activity_at': lambda x: x.get('last_seen_at'),
         },
+        'url_mutations': [
+            {
+                # Matches /u/<name> and the sub-routes a profile link carries —
+                # maigret stores Discourse accounts as /u/<name>/summary. The base
+                # is captured rather than the host alone because plenty of forums
+                # live under a path (freecodecamp.org/forum). Dots are allowed in
+                # the name (a.shishkin is a real one); only a trailing .json is
+                # refused, so an already mutated URL is left alone.
+                'from': r'https?://(?P<base>[^?#]*?)/+u/(?P<username>[^/?#]+?)(?<!\.json)(?:/|$|[?#])',
+                'to': 'https://{base}/u/{username}.json',
+            },
+        ],
     },
     'Snapchat': {
         'flags': ['__NEXT_DATA__', '"userProfile":'],
@@ -4669,28 +4644,24 @@ schemes = {
             'mastodon_id': lambda x: x.find('meta', {'property': 'profile:username'})['content'] if x.find('meta', {'property': 'profile:username'}) else None,
         },
     },
+    # Recognised by the generator meta tag every Discourse instance emits; the
+    # data-preloaded attribute this used to key on is gone from current versions.
     'Discourse HTML profile': {
-        'flags': ['data-preloaded=', 'discourse_theme_id', 'discourse_current_homepage'],
-        'bs': True,
+        'flags': ['name="generator" content="Discourse', 'discourse_theme_id'],
+        'regex': r'^([\s\S]+)$',
+        'extract_json': True,
+        'transforms': [_discourse_html_profile],
         'fields': {
-            'uid': lambda x: _discourse_user_field(x, 'id'),
-            'username': lambda x: _discourse_user_field(x, 'username'),
-            'fullname': lambda x: _discourse_user_field(x, 'name') or None,
-            'title': lambda x: _discourse_user_field(x, 'title') or None,
-            'website': lambda x: _discourse_user_field(x, 'website') or None,
-            'image': lambda x: (_discourse_user_field(x, 'avatar_template') or '').replace('{size}', '240') or None,
-            'trust_level': lambda x: _discourse_user_field(x, 'trust_level'),
-            'is_moderator': lambda x: _discourse_user_field(x, 'moderator'),
-            'is_admin': lambda x: _discourse_user_field(x, 'admin'),
-            'badge_count': lambda x: _discourse_user_field(x, 'badge_count'),
-            'views_count': lambda x: _discourse_user_field(x, 'profile_view_count'),
-            'created_at': lambda x: _discourse_user_field(x, 'created_at'),
-            'latest_activity_at': lambda x: _discourse_user_field(x, 'last_seen_at'),
+            'username': lambda x: x.get('username'),
+            'bio': lambda x: x.get('bio') or None,
+            'image': lambda x: x.get('image') or None,
         },
-        'url_mutations': [{
-            'from': r'https?://(?P<domain>[^/]+)/u/(?P<username>[^/?#.]+)/summary',
-            'to': 'https://{domain}/u/{username}',
-        }],
+        'url_mutations': [
+            {
+                'from': r'https?://(?P<host>[^/]+)/u/(?P<username>[^/?#.]+)/summary',
+                'to': 'https://{host}/u/{username}',
+            },
+        ],
     },
     'Mastodon API': {
         'url_hints': tuple(_MASTODON_INSTANCES),
@@ -4718,41 +4689,6 @@ schemes = {
                 'to': 'https://' + d + '/api/v1/accounts/lookup?acct={username}',
             }
             for d in _MASTODON_INSTANCES
-        ],
-    },
-    'Discourse Forums': {
-        'url_hints': tuple(_DISCOURSE_INSTANCES),
-        'flags': ['"trust_level"', '"badge_count"', '"profile_view_count"'],
-        'regex': r'^(\{[\s\S]+\})$',
-        'extract_json': True,
-        'transforms': [
-            json.loads,
-            lambda x: x.get('user', {}),
-            json.dumps,
-        ],
-        'fields': {
-            'uid': lambda x: x.get('id'),
-            'username': lambda x: x.get('username'),
-            'fullname': lambda x: x.get('name') or None,
-            'title': lambda x: x.get('title') or None,
-            'bio': lambda x: x.get('bio_raw') or None,
-            'website': lambda x: x.get('website') or None,
-            'location': lambda x: x.get('location') or None,
-            'image': lambda x: x.get('avatar_template', '').replace('{size}', '240') or None,
-            'trust_level': lambda x: x.get('trust_level'),
-            'is_moderator': lambda x: x.get('moderator'),
-            'is_admin': lambda x: x.get('admin'),
-            'badge_count': lambda x: x.get('badge_count'),
-            'views_count': lambda x: x.get('profile_view_count'),
-            'created_at': lambda x: x.get('created_at'),
-            'latest_activity_at': lambda x: x.get('last_seen_at'),
-        },
-        'url_mutations': [
-            {
-                'from': r'https?://' + d.replace('.', r'\.') + r'/u/(?P<username>[^/?#.]+)',
-                'to': 'https://' + d + '/u/{username}.json',
-            }
-            for d in _DISCOURSE_INSTANCES
         ],
     },
     'FL.ru': {

--- a/socid_extractor/url_relevance.py
+++ b/socid_extractor/url_relevance.py
@@ -28,4 +28,10 @@ def check_url_relevance(url):
         for hint in (*hints, *_name_fallback_tokens(scheme_name)):
             if len(hint) > 1 and hint in low:
                 return True
+        # A scheme that knows how to rewrite this URL is a hint in itself: schemes
+        # keyed on a route rather than on a host (Discourse and the like) match any
+        # domain, and listing those domains by hand is exactly what they avoid.
+        for mutation in scheme_data.get('url_mutations') or ():
+            if re.search(mutation['from'], url):
+                return True
     return False

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1780,3 +1780,25 @@ def test_visnesscard_api_e2e():
     assert info.get('email')
     assert info.get('company') == 'GRINDTIME FITNESS'
     assert 'Detroit' in info.get('location', '')
+
+
+def test_discourse_api():
+    """Discourse API"""
+    # a host that is not in the url_hints list — the mutation has to carry it
+    url, _ = mutate_url('https://discuss.python.org/u/hugovk')[0]
+    info = extract(parse(url)[0])
+
+    assert info.get('uid') == '358'
+    assert info.get('username') == 'hugovk'
+    assert info.get('trust_level')
+    assert info.get('created_at')
+
+
+def test_discourse_html_profile():
+    """Discourse HTML profile"""
+    # the HTML shell, which is all that is left when an instance closes its API
+    info = extract(parse('https://discuss.python.org/u/hugovk')[0])
+
+    assert info.get('username') == 'hugovk'
+    assert info.get('bio')
+    assert 'user_avatar' in info.get('image', '')

--- a/tests/test_socid_improvements.py
+++ b/tests/test_socid_improvements.py
@@ -1344,6 +1344,49 @@ def test_orcid_url_mutations_target_five_platforms():
 # Structural / meta tests
 # ---------------------------------------------------------------------------
 
+def test_discourse_mutation_covers_the_shapes_maigret_stores():
+    """maigret keeps Discourse accounts as {urlMain}/u/{username}/summary."""
+    from socid_extractor.main import mutate_url
+
+    def mutated(url):
+        return [u for u, _ in mutate_url(url) if u.endswith('.json')]
+
+    # the plain profile link, and the /summary one that goes into the database
+    assert mutated('https://forum.ansible.com/u/sivel') == ['https://forum.ansible.com/u/sivel.json']
+    assert mutated('https://forum.ansible.com/u/sivel/summary') == ['https://forum.ansible.com/u/sivel.json']
+    # a forum living under a path, with the doubled slash the database renders
+    assert mutated('https://www.freecodecamp.org/forum//u/JeremyLT/summary') == [
+        'https://www.freecodecamp.org/forum/u/JeremyLT.json']
+    # dots belong in Discourse usernames
+    assert mutated('https://forum.cs-cart.ru/u/a.shishkin/summary') == [
+        'https://forum.cs-cart.ru/u/a.shishkin.json']
+    # but an already mutated URL must not collect a second .json
+    assert mutated('https://forum.ansible.com/u/sivel.json') == []
+    # and a thread is not a profile
+    assert mutated('https://discuss.python.org/t/some-thread/1234') == []
+
+
+def test_discourse_html_only_fires_on_a_profile():
+    """Every page of a forum has the generator tag and other people's avatars."""
+    shell = (
+        '<meta name="generator" content="Discourse 2026.9.0-latest - https://github.com/discourse/discourse">'
+        '<meta id="data-discourse-setup" data-discourse_theme_id="2">'
+        '<meta property="og:image" content="https://cdn/user_avatar/forum.example/someone/45/1_2.png">'
+    )
+    profile = shell + '<link rel="canonical" href="https://forum.example/u/sivel">'
+    topic = shell + '<link rel="canonical" href="https://forum.example/t/some-thread/1234">'
+
+    assert extract(profile).get('username') == 'sivel'
+    # a thread names whoever posted in it first — that is not the page's subject
+    assert extract(topic) == {}
+    # instances that refuse anonymous profiles still serve the canonical link, so a
+    # username with nothing of the account's own attached is the request echoed back
+    deny = ('<meta name="generator" content="Discourse 2026.9.0-latest">'
+            '<meta id="data-discourse-setup" data-discourse_theme_id="2">'
+            '<link rel="canonical" href="https://forum.example/u/sivel">')
+    assert extract(deny) == {}
+
+
 def test_no_flag_subset_shadows():
     """Detect scheme pairs where one's flags are a subset of another's.
 


### PR DESCRIPTION
Discourse serves the same JSON everywhere, so the mutation keys on the `/u/{username}` route instead of forty hardcoded hosts. Checked against every Discourse entry in maigret's database — 464 of 464 mutate, including the `/summary` links it actually stores, forums living under a path, doubled slashes and dots in usernames.

`url_relevance` now counts a matching mutation as a hint. A scheme keyed on a route cannot list its domains, and `--skip-fetch-if-no-url-hint` was throwing those URLs away before the request.

`Discourse HTML profile` keyed on a `data-preloaded` attribute current versions no longer emit, so it matched nothing. It goes by the `generator` meta tag now and reads username, bio and avatar — there is no user id in the HTML. It only fires on a profile page, and only when something the account owns comes with the name: every page of a forum carries that tag, and instances that refuse anonymous profiles still serve the canonical link, which would otherwise confirm every name asked about.

`Discourse Forums` is dropped — it duplicated `Discourse API` field for field, and with identical flags it never won a match anyway. `Discourse API` itself is untouched apart from gaining the mutation: same flags, same fields, byte-identical output on a real `.json` response.
