### PR TITLE
Update the counts in README and the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > Turn any public profile page into a structured account record — usernames, display names, bios, avatars, locations, joined-at dates, follower counts, external links, and the **stable internal identifiers** that uniquely pin an account across renames, redesigns, and deletions.
 
-`socid_extractor` parses HTML pages and API responses from 130+ platforms and returns a flat, machine-readable dictionary of account fields. No API keys required, no headless browser — just a single function call on response text.
+`socid_extractor` parses HTML pages and API responses from 250+ schemes and returns a flat, machine-readable dictionary of account fields. No API keys required, no headless browser — just a single function call on response text.
 
 **Why it's useful**
 
@@ -76,7 +76,7 @@ $ socid_extractor --url https://example.com/foo --skip-fetch-if-no-url-hint
 
 ## Supported sites
 
-[**260+ schemes** — see METHODS.md for the full list.](https://github.com/soxoj/socid-extractor/blob/master/METHODS.md)
+[**250+ schemes**, covering roughly 2,000 of the sites Maigret checks — see METHODS.md for the full list.](https://github.com/soxoj/socid-extractor/blob/master/METHODS.md)
 
 A non-exhaustive sample:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ usernames, display names, bios, avatars, locations, joined-at dates, follower co
 external links, and the **stable internal identifiers** that uniquely pin an account
 across renames, redesigns, and deletions.
 
-It parses HTML pages and API responses from 130+ platforms and returns a flat,
+It parses HTML pages and API responses from 250+ schemes and returns a flat,
 machine-readable dictionary of account fields. No API keys required, no headless
 browser — just a single :func:`~socid_extractor.extract` call on response text.
 

--- a/docs/source/locale/zh_CN/LC_MESSAGES/index.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/index.po
@@ -50,12 +50,12 @@ msgstr ""
 
 #: ../../source/index.rst:11 549d593dab134fd09dbd18740375f8af
 msgid ""
-"It parses HTML pages and API responses from 130+ platforms and returns a "
+"It parses HTML pages and API responses from 250+ schemes and returns a "
 "flat, machine-readable dictionary of account fields. No API keys required, "
 "no headless browser — just a single :func:`~socid_extractor.extract` call on"
 " response text."
 msgstr ""
-"它解析来自 130+ 个平台的 HTML 页面和 API 响应，并返回一个扁平的、机器可读的账户字段字典。无需 API "
+"它解析来自 250+ 种提取方案的 HTML 页面和 API 响应，并返回一个扁平的、机器可读的账户字段字典。无需 API "
 "密钥，也无需无头浏览器——只需对响应文本调用一次 :func:`~socid_extractor.extract`。"
 
 #: ../../source/index.rst:15 fb84ed7f05fb49858f7bd4d825f4abe0

--- a/docs/source/locale/zh_CN/LC_MESSAGES/supported-sites.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/supported-sites.po
@@ -26,11 +26,11 @@ msgstr "支持的站点"
 
 #: ../../source/supported-sites.rst:6 a22904d1e2984a649353d4aad360bc7f
 msgid ""
-"socid_extractor ships **130+ extraction schemes**. Each scheme targets one "
+"socid_extractor ships **250+ extraction schemes**. Each scheme targets one "
 "page shape — a site's profile HTML, a public JSON API, or an embedded state "
 "blob — and maps it onto the standard :doc:`field ontology <ontology>`."
 msgstr ""
-"socid_extractor 内置 **130+ 种提取方案**\\ 。每种提取方案针对一种页面形态——站点的个人资料页 HTML、公开的 JSON "
+"socid_extractor 内置 **250+ 种提取方案**\\ 。每种提取方案针对一种页面形态——站点的个人资料页 HTML、公开的 JSON "
 "API，或嵌入的状态数据块——并将其映射到标准的 :doc:`字段本体 <ontology>`。"
 
 #: ../../source/supported-sites.rst:11 4e448527d3e2496c922e35b817d6c598

--- a/docs/source/supported-sites.rst
+++ b/docs/source/supported-sites.rst
@@ -3,7 +3,7 @@
 Supported sites
 ===============
 
-socid_extractor ships **130+ extraction schemes**. Each scheme targets one page shape —
+socid_extractor ships **250+ extraction schemes**. Each scheme targets one page shape —
 a site's profile HTML, a public JSON API, or an embedded state blob — and maps it onto
 the standard :doc:`field ontology <ontology>`.
 


### PR DESCRIPTION
The README still said 130+ platforms. It is 250+ schemes now, and because the engine schemes (Discourse, uCoz, vBulletin) each cover hundreds of hosts, they reach roughly 2,000 of the sites Maigret checks. The Chinese translations carry the same numbers so the localised pages don't fall back to English.
