### PR TITLE
Don't let one scheme's transform error kill the whole extraction

### DIFF
--- a/socid_extractor/main.py
+++ b/socid_extractor/main.py
@@ -104,6 +104,12 @@ def _extract_by_schemes(page):
 
                 transformed = transform(scheme_data, extracted)
 
+                if not isinstance(transformed, str):
+                    # a transform hit PROCESS_ERRORS and gave up; that is this
+                    # scheme's problem, not a reason to fail the whole page
+                    logging.debug('Transform did not produce JSON, skipping scheme')
+                    continue
+
                 json_data = json.loads(transformed)
 
                 if json_data == {}:

--- a/tests/test_socid_improvements.py
+++ b/tests/test_socid_improvements.py
@@ -1387,6 +1387,40 @@ def test_discourse_html_only_fires_on_a_profile():
     assert extract(deny) == {}
 
 
+def test_a_broken_transform_skips_only_its_own_scheme():
+    """A transform that gives up must not take the rest of the page with it."""
+    from socid_extractor.schemes import schemes
+
+    marker = '"pipeline-guard-fixture"'
+    # transform() turns a PROCESS_ERRORS failure into {} — a dict, not the '{}'
+    # string json.loads expects. Chains ending in json.dumps paper over it; this
+    # one ends on the failure, like Reddit, DeviantArt and SlideShare do.
+    broken = {
+        'flags': [marker],
+        'regex': r'^([\s\S]+)$',
+        'extract_json': True,
+        'transforms': [lambda x: json.loads(x)['missing']],
+    }
+    working = {
+        'flags': [marker],
+        'regex': r'^([\s\S]+)$',
+        'extract_json': True,
+        'transforms': [json.loads, lambda x: {'username': x['user']}, json.dumps],
+        'fields': {'username': lambda x: x.get('username')},
+    }
+
+    original = dict(schemes)
+    schemes.clear()
+    schemes.update({'Broken fixture': broken, 'Working fixture': working, **original})
+    try:
+        info = extract('{"pipeline-guard-fixture": 1, "user": "bob"}')
+    finally:
+        schemes.clear()
+        schemes.update(original)
+
+    assert info.get('username') == 'bob'
+
+
 def test_no_flag_subset_shadows():
     """Detect scheme pairs where one's flags are a subset of another's.
 


### PR DESCRIPTION
`transform()` catches a failing transform and hands back `{}` — a dict, not the `'{}'` string `json.loads` is about to be given. The resulting `TypeError` isn't caught anywhere, so it escapes `extract()` and takes every other scheme for that page with it.

Most chains end in `json.dumps`, which turns that dict back into `'{}'` and lands on the `json_data == {}` check the author clearly intended. The four whose chain ends on the failure itself — Reddit, DeviantArt, SlideShare and Discourse HTML profile — crash instead. Found the hard way: a regex without a capture group in the Discourse helper raised `IndexError`, and a live profile page stopped extracting entirely.

The scheme is skipped now, like any other scheme that can't parse what it got. The test registers a broken and a working scheme over the same body and checks the working one still returns its field; it fails on master with that same `TypeError`.
