### PR TITLE
Patreon: rewrite scheme for Next.js, add App Router variant

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -12,258 +12,259 @@
 7 | GitHub API | [github_api](https://github.com/soxoj/socid-extractor/search?q=test_github_api) | broken |
 8 | GitHub Social Accounts API |  |  |
 9 | Gitlab API |  |  |
-10 | Patreon | [patreon](https://github.com/soxoj/socid-extractor/search?q=test_patreon) | broken |
-11 | Flickr | [flickr](https://github.com/soxoj/socid-extractor/search?q=test_flickr) | failed from github CI infra IPs |
-12 | Virgool |  |  |
-13 | Yandex Disk file | [yandex_disk](https://github.com/soxoj/socid-extractor/search?q=test_yandex_disk) | broken |
-14 | Yandex Disk photoalbum |  |  |
-15 | Yandex Music AJAX request | [yandex_music_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_yandex_music_user_profile) | captcha |
-16 | Yandex Q (Znatoki) user profile |  |  |
-17 | Yandex Market user profile |  |  |
-18 | Yandex Music API |  |  |
-19 | Yandex Realty offer |  |  |
-20 | Yandex Collections |  |  |
-21 | Yandex Collections API | [yandex_collections_api](https://github.com/soxoj/socid-extractor/search?q=test_yandex_collections_api) | service no longer public |
-22 | Yandex Reviews user profile | [yandex_reviews](https://github.com/soxoj/socid-extractor/search?q=test_yandex_reviews) | anti-bot / captcha / rate limiting from the site |
-23 | Yandex Zen user profile | [yandex_zen_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_yandex_zen_user_profile) | failed from github CI infra IPs |
-24 | Yandex messenger search API |  |  |
-25 | Yandex messenger profile API |  |  |
-26 | Yandex Bugbounty user profile |  |  |
-27 | Yandex O | [yandex_o_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_yandex_o_user_profile) | down. service no longer exists |
-28 | VK user profile foaf page | [vk_foaf](https://github.com/soxoj/socid-extractor/search?q=test_vk_foaf), [vk_user_profile_no_username](https://github.com/soxoj/socid-extractor/search?q=test_vk_user_profile_no_username) | VK foaf.php returns empty body for unauthenticated clients (2026), VK web is SPA; static fetch has no embed with ownerId (2026) |
-29 | VK user profile | [vk_blocked_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_vk_blocked_user_profile), [vk_closed_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_vk_closed_user_profile), [vk_user_profile_full](https://github.com/soxoj/socid-extractor/search?q=test_vk_user_profile_full), [vk_user_profile_no_username](https://github.com/soxoj/socid-extractor/search?q=test_vk_user_profile_no_username) | broken, VK web is SPA; static fetch has no embed with ownerId (2026), VK web is SPA; static fetch has no embed with ownerId (2026), VK web is SPA; static fetch has no embed with ownerId (2026) |
-30 | VK closed user profile |  |  |
-31 | VK blocked user profile |  |  |
-32 | Gravatar | [gravatar](https://github.com/soxoj/socid-extractor/search?q=test_gravatar) | broken |
-33 | Instagram | [instagram](https://github.com/soxoj/socid-extractor/search?q=test_instagram) | requests from GitHub Actions CI servers are blocked, broken. needs deeper rework |
-34 | Instagram API | [instagram_api](https://github.com/soxoj/socid-extractor/search?q=test_instagram_api) | requests from GitHub Actions CI servers are blocked |
-35 | Instagram page JSON | [instagram](https://github.com/soxoj/socid-extractor/search?q=test_instagram) | requests from GitHub Actions CI servers are blocked, broken. needs deeper rework |
-36 | Instagram GraphQL | [instagram_graphql_bio_links_and_tagged_usernames](https://github.com/soxoj/socid-extractor/search?q=test_instagram_graphql_bio_links_and_tagged_usernames), [instagram_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_instagram_graphql_e2e) | anti-bot / captcha / rate limiting from the site, requests from GitHub Actions CI servers are blocked |
-37 | Spotify API |  |  |
-38 | EyeEm | [eyeem](https://github.com/soxoj/socid-extractor/search?q=test_eyeem) | EyeEm returns 403 for automated clients (2026) |
-39 | Medium RSS |  |  |
-40 | Medium | [medium](https://github.com/soxoj/socid-extractor/search?q=test_medium) |  |
-41 | Odnoklassniki | [odnoklassniki](https://github.com/soxoj/socid-extractor/search?q=test_odnoklassniki) |  |
-42 | Habrahabr HTML (old) |  |  |
-43 | Habrahabr JSON | [habr](https://github.com/soxoj/socid-extractor/search?q=test_habr), [habr_no_image](https://github.com/soxoj/socid-extractor/search?q=test_habr_no_image) | requests from GitHub Actions CI servers are blocked, requests from GitHub Actions CI servers are blocked |
-44 | My Mail.ru |  |  |
-45 | Behance | [behance](https://github.com/soxoj/socid-extractor/search?q=test_behance) | broken |
-46 | Blogger | [blogger](https://github.com/soxoj/socid-extractor/search?q=test_blogger) | Failed in GitHub CI |
-47 | D3.ru | [d3](https://github.com/soxoj/socid-extractor/search?q=test_d3) | requests from GitHub Actions CI servers are blocked |
-48 | Gitlab |  |  |
-49 | 500px userByUsername API |  |  |
-50 | 500px GraphQL API | [500px](https://github.com/soxoj/socid-extractor/search?q=test_500px) |  |
-51 | Google Document API | [google_documents](https://github.com/soxoj/socid-extractor/search?q=test_google_documents) |  |
-52 | Google Document |  |  |
-53 | Google Maps contributions |  |  |
-54 | YouTube ytInitialData |  |  |
-55 | Youtube Channel |  |  |
-56 | Bitbucket | [bitbucket](https://github.com/soxoj/socid-extractor/search?q=test_bitbucket) | Bitbucket UI/embed changed; test user URL 404 (2026) |
-57 | Pinterest profile/board page | [pinterest_account](https://github.com/soxoj/socid-extractor/search?q=test_pinterest_account) |  |
-58 | Reddit | [reddit](https://github.com/soxoj/socid-extractor/search?q=test_reddit) | broken |
-59 | Steam | [steam](https://github.com/soxoj/socid-extractor/search?q=test_steam) | cloudflare |
-60 | Steam Community Group |  |  |
-61 | Steam Addiction |  |  |
-62 | Stack Exchange API | [stack_exchange_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_stack_exchange_api_e2e) | anti-bot / captcha / rate limiting from the site |
-63 | Stack Overflow & similar |  |  |
-64 | SoundCloud | [soundcloud](https://github.com/soxoj/socid-extractor/search?q=test_soundcloud) | SoundCloud returns 403 / empty embed for automated clients (2026) |
-65 | TikTok | [tiktok](https://github.com/soxoj/socid-extractor/search?q=test_tiktok), [tiktok_hydration_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tiktok_hydration_e2e) | requests from GitHub Actions CI servers are blocked, requests from GitHub Actions CI servers are blocked |
-66 | TikTok (legacy SIGI_STATE) | [tiktok_hydration_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tiktok_hydration_e2e) | requests from GitHub Actions CI servers are blocked |
-67 | Picsart API | [picsart_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_picsart_api_e2e) | requests from GitHub Actions CI servers are blocked |
-68 | VC.ru |  |  |
-69 | LiveJournal | [livejournal](https://github.com/soxoj/socid-extractor/search?q=test_livejournal) | requests from GitHub Actions CI servers are blocked |
-70 | MySpace | [myspace](https://github.com/soxoj/socid-extractor/search?q=test_myspace) | doesnt work without proxy, 503 error |
-71 | Keybase API |  |  |
-72 | Wikimapia |  |  |
-73 | Vimeo HTML | [vimeo_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_vimeo_html_e2e) | requests from GitHub Actions CI servers are blocked |
-74 | Vimeo GraphQL API |  |  |
-75 | DeviantArt | [deviantart](https://github.com/soxoj/socid-extractor/search?q=test_deviantart) | it works but is skipped for the sake of successful tests |
-76 | mssg.me | [mssg_me](https://github.com/soxoj/socid-extractor/search?q=test_mssg_me) | broken |
-77 | Telegram | [telegram](https://github.com/soxoj/socid-extractor/search?q=test_telegram) |  |
-78 | BuzzFeed | [buzzfeed](https://github.com/soxoj/socid-extractor/search?q=test_buzzfeed) | requests from GitHub Actions CI servers are blocked |
-79 | Linktree | [linktree](https://github.com/soxoj/socid-extractor/search?q=test_linktree) | broken |
-80 | Twitch | [twitch](https://github.com/soxoj/socid-extractor/search?q=test_twitch) | broken |
-81 | vBulletinEngine |  |  |
-82 | Tumblr (default theme) |  |  |
-83 | 1x.com |  |  |
-84 | Last.fm | [last_fm](https://github.com/soxoj/socid-extractor/search?q=test_last_fm) | requests from GitHub Actions CI servers are blocked |
-85 | Ask.fm | [ask_fm](https://github.com/soxoj/socid-extractor/search?q=test_ask_fm) | broken |
-86 | Launchpad | [launchpad](https://github.com/soxoj/socid-extractor/search?q=test_launchpad) | requests from GitHub Actions CI servers are blocked |
-87 | Xakep.ru |  |  |
-88 | Tproger.ru | [tproger_ru](https://github.com/soxoj/socid-extractor/search?q=test_tproger_ru) | no more author pages for now |
-89 | Jsfiddle.net |  |  |
-90 | Disqus API | [disqus_api](https://github.com/soxoj/socid-extractor/search?q=test_disqus_api) |  |
-91 | uCoz-like profile page |  |  |
-92 | uID.me |  |  |
-93 | tapd | [tapd](https://github.com/soxoj/socid-extractor/search?q=test_tapd) | down |
-94 | freelancer.com |  |  |
-95 | Yelp | [yelp_userid](https://github.com/soxoj/socid-extractor/search?q=test_yelp_userid), [yelp_username](https://github.com/soxoj/socid-extractor/search?q=test_yelp_username) | broken, broken |
-96 | Trello API | [trello](https://github.com/soxoj/socid-extractor/search?q=test_trello) |  |
-97 | Weibo API | [weibo_api](https://github.com/soxoj/socid-extractor/search?q=test_weibo_api), [weibo_api_by_id](https://github.com/soxoj/socid-extractor/search?q=test_weibo_api_by_id) | requests from GitHub Actions CI servers are blocked, requests from GitHub Actions CI servers are blocked |
-98 | Weibo | [weibo](https://github.com/soxoj/socid-extractor/search?q=test_weibo) | needs rework, cookies are required to get content, requests from GitHub Actions CI servers are blocked |
-99 | ICQ | [icq](https://github.com/soxoj/socid-extractor/search?q=test_icq) | broken forever |
-100 | Pastebin | [pastebin](https://github.com/soxoj/socid-extractor/search?q=test_pastebin) |  |
-101 | Periscope |  |  |
-102 | Imgur API | [imgur_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_imgur_api_e2e) |  |
-103 | PayPal |  |  |
-104 | Tinder | [tinder](https://github.com/soxoj/socid-extractor/search?q=test_tinder) | broken |
-105 | ifunny.co | [ifunny_co](https://github.com/soxoj/socid-extractor/search?q=test_ifunny_co) |  |
-106 | Wattpad API | [wattpad_api](https://github.com/soxoj/socid-extractor/search?q=test_wattpad_api) | Wattpad API endpoint is unavailable / unstable from CI (2026) |
-107 | Kik | [kik](https://github.com/soxoj/socid-extractor/search?q=test_kik) | broken |
-108 | Docker Hub API | [docker_hub_api](https://github.com/soxoj/socid-extractor/search?q=test_docker_hub_api) |  |
-109 | Mixcloud API | [mixcloud_api](https://github.com/soxoj/socid-extractor/search?q=test_mixcloud_api) |  |
-110 | binarysearch API | [binarysearch_api](https://github.com/soxoj/socid-extractor/search?q=test_binarysearch_api) | down |
-111 | pr0gramm API | [pr0gramm_api](https://github.com/soxoj/socid-extractor/search?q=test_pr0gramm_api) |  |
-112 | Aparat API | [aparat_api](https://github.com/soxoj/socid-extractor/search?q=test_aparat_api) | broken |
-113 | UnstoppableDomains |  |  |
-114 | memory.lol | [memory_lol](https://github.com/soxoj/socid-extractor/search?q=test_memory_lol) |  |
-115 | Duolingo API | [duolingo_api](https://github.com/soxoj/socid-extractor/search?q=test_duolingo_api) |  |
-116 | TwitchTracker |  |  |
-117 | Chess.com API | [chess_com_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_chess_com_api_e2e) |  |
-118 | Roblox user API | [roblox_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_roblox_api_e2e) |  |
-119 | Roblox username lookup API |  |  |
-120 | MyAnimeList profile |  |  |
-121 | XVideos profile |  |  |
-122 | lnk.bio |  |  |
-123 | Wikipedia user API |  |  |
-124 | Fandom MediaWiki API |  |  |
-125 | Substack public profile API |  |  |
-126 | Lesswrong GraphQL API |  |  |
-127 | hashnode GraphQL API |  |  |
-128 | Rarible API |  |  |
-129 | CSSBattle |  |  |
-130 | Max (max.ru) profile |  |  |
-131 | Bluesky API |  |  |
-132 | Scratch API |  |  |
-133 | DailyMotion API |  |  |
-134 | SlideShare |  |  |
-135 | WordPress.org Profile |  |  |
-136 | Weebly |  |  |
-137 | Calendly |  |  |
-138 | Google Play Developer |  |  |
-139 | Amazon Author |  |  |
-140 | Habr |  |  |
-141 | Taplink |  |  |
-142 | Product Hunt |  |  |
-143 | Chess.com HTML | [chess_com_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_chess_com_html_e2e) | chess.com HTML endpoint times out from CI (2026) |
-144 | Roblox HTML | [roblox_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_roblox_html_e2e) |  |
-145 | LeetCode GraphQL | [leetcode_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_leetcode_graphql_e2e) |  |
-146 | Boosty API | [boosty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_boosty_api_e2e) |  |
-147 | Threads |  |  |
-148 | Smule |  |  |
-149 | Warpcast API | [warpcast_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_warpcast_api_e2e) |  |
-150 | Paragraph API | [paragraph_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_paragraph_api_e2e) |  |
-151 | Fragment | [fragment_e2e](https://github.com/soxoj/socid-extractor/search?q=test_fragment_e2e) |  |
-152 | Tonometerbot | [tonometerbot_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tonometerbot_e2e) | anti-bot / captcha / rate limiting from the site |
-153 | Spatial | [spatial_e2e](https://github.com/soxoj/socid-extractor/search?q=test_spatial_e2e) | requests from GitHub Actions CI servers are blocked |
-154 | OpenSea |  |  |
-155 | Hive Blog |  |  |
-156 | ORCID API |  |  |
-157 | OpenAlex Authors API |  |  |
-158 | arXiv author page |  |  |
-159 | DBLP person record |  |  |
-160 | Scholia author profile |  |  |
-161 | BuyMeACoffee | [buymeacoffee](https://github.com/soxoj/socid-extractor/search?q=test_buymeacoffee) |  |
-162 | Discourse API | [discourse_api](https://github.com/soxoj/socid-extractor/search?q=test_discourse_api) |  |
-163 | Snapchat | [snapchat](https://github.com/soxoj/socid-extractor/search?q=test_snapchat) |  |
-164 | Bio Site | [bio_site](https://github.com/soxoj/socid-extractor/search?q=test_bio_site) |  |
-165 | Faceit API | [faceit_api](https://github.com/soxoj/socid-extractor/search?q=test_faceit_api) |  |
-166 | Fansly API | [fansly_api](https://github.com/soxoj/socid-extractor/search?q=test_fansly_api) |  |
-167 | Codewars API |  |  |
-168 | Minds API |  |  |
-169 | HackerNoon API |  |  |
-170 | Polar API |  |  |
-171 | thanks.dev API |  |  |
-172 | Matrix profile API |  |  |
-173 | osu! | [osu](https://github.com/soxoj/socid-extractor/search?q=test_osu) |  |
-174 | Lens (Hey/Orb/Buttrfly) account | [lens_account](https://github.com/soxoj/socid-extractor/search?q=test_lens_account), [lens_account_absent](https://github.com/soxoj/socid-extractor/search?q=test_lens_account_absent) |  |
-175 | HuggingFace API | [huggingface_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_huggingface_api_e2e) |  |
-176 | HackerNews | [hackernews](https://github.com/soxoj/socid-extractor/search?q=test_hackernews) |  |
-177 | Teletype | [teletype](https://github.com/soxoj/socid-extractor/search?q=test_teletype) |  |
-178 | GDBrowser API | [gdbrowser_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_gdbrowser_api_e2e) |  |
-179 | StreamElements API | [streamelements_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamelements_api_e2e) |  |
-180 | Streamlabs API | [streamlabs_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamlabs_api_e2e) |  |
-181 | Donatty API | [donatty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_donatty_api_e2e) |  |
-182 | VisnessCard API | [visnesscard_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_visnesscard_api_e2e) | requests from GitHub Actions CI servers are blocked |
-183 | Codeforces API |  |  |
-184 | Discogs API |  |  |
-185 | iNaturalist API |  |  |
-186 | Pronouny API |  |  |
-187 | Zepeto API |  |  |
-188 | OnlyFans API |  |  |
-189 | eToro API |  |  |
-190 | Gettr API |  |  |
-191 | Habbo API |  |  |
-192 | Hackadvisor API |  |  |
-193 | Pillowfort JSON API |  |  |
-194 | Scored API |  |  |
-195 | YesWeHack API |  |  |
-196 | Destream API |  |  |
-197 | Tipeeestream API |  |  |
-198 | Komi API |  |  |
-199 | Cropty API |  |  |
-200 | Redgifs API |  |  |
-201 | Tappy API |  |  |
-202 | Komoot API |  |  |
-203 | Tapitag API |  |  |
-204 | Vivino API |  |  |
-205 | Google Scholar |  |  |
-206 | Snapchat profile |  |  |
-207 | Flipboard profile |  |  |
-208 | Clubhouse profile |  |  |
-209 | Coda.io profile |  |  |
-210 | Poe.com profile |  |  |
-211 | Gumroad profile |  |  |
-212 | Mastodon HTML profile |  |  |
-213 | Discourse HTML profile | [discourse_html_profile](https://github.com/soxoj/socid-extractor/search?q=test_discourse_html_profile) |  |
-214 | Mastodon API |  |  |
-215 | FL.ru |  |  |
-216 | Manifold Markets |  |  |
-217 | VSCO |  |  |
-218 | Mojang API |  |  |
-219 | OP.GG |  |  |
-220 | coder.social |  |  |
-221 | GOG |  |  |
-222 | Kick API |  |  |
-223 | Academia.edu |  |  |
-224 | TradingView |  |  |
-225 | Geocaching |  |  |
-226 | Rutracker |  |  |
-227 | Weburg |  |  |
-228 | Pokemon Showdown |  |  |
-229 | ImageShack |  |  |
-230 | Replit |  |  |
-231 | Itch.io |  |  |
-232 | Giphy |  |  |
-233 | Wattpad HTML profile |  |  |
-234 | Venmo |  |  |
-235 | Tumblr blog |  |  |
-236 | Drive2.ru |  |  |
-237 | Lichess API |  |  |
-238 | Hackerrank API |  |  |
-239 | Kongregate API |  |  |
-240 | WordPress.com site API |  |  |
-241 | Codecademy profile |  |  |
-242 | About.me profile |  |  |
-243 | Fur Affinity profile |  |  |
-244 | Pikabu profile |  |  |
-245 | Codepen profile |  |  |
-246 | Letterboxd profile |  |  |
-247 | Gitee profile |  |  |
-248 | Slack workspace |  |  |
-249 | Instructables member |  |  |
-250 | Envato Author profile |  |  |
-251 | Kwork freelancer |  |  |
-252 | Freesound user |  |  |
-253 | Star Citizen citizen |  |  |
-254 | Dribbble profile |  |  |
-255 | Depop shop |  |  |
-256 | ModDB member |  |  |
-257 | Xbox Gamertag |  |  |
-258 | DonationAlerts streamer |  |  |
-259 | CCM profile |  |  |
-260 | Wikidot user |  |  |
-261 | Couchsurfing person |  |  |
-262 | ReverbNation artist |  |  |
+10 | Patreon | [patreon](https://github.com/soxoj/socid-extractor/search?q=test_patreon) | anti-bot / captcha / rate limiting from the site |
+11 | Patreon RSC | [patreon_rsc](https://github.com/soxoj/socid-extractor/search?q=test_patreon_rsc) | anti-bot / captcha / rate limiting from the site |
+12 | Flickr | [flickr](https://github.com/soxoj/socid-extractor/search?q=test_flickr) | failed from github CI infra IPs |
+13 | Virgool |  |  |
+14 | Yandex Disk file | [yandex_disk](https://github.com/soxoj/socid-extractor/search?q=test_yandex_disk) | broken |
+15 | Yandex Disk photoalbum |  |  |
+16 | Yandex Music AJAX request | [yandex_music_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_yandex_music_user_profile) | captcha |
+17 | Yandex Q (Znatoki) user profile |  |  |
+18 | Yandex Market user profile |  |  |
+19 | Yandex Music API |  |  |
+20 | Yandex Realty offer |  |  |
+21 | Yandex Collections |  |  |
+22 | Yandex Collections API | [yandex_collections_api](https://github.com/soxoj/socid-extractor/search?q=test_yandex_collections_api) | service no longer public |
+23 | Yandex Reviews user profile | [yandex_reviews](https://github.com/soxoj/socid-extractor/search?q=test_yandex_reviews) | anti-bot / captcha / rate limiting from the site |
+24 | Yandex Zen user profile | [yandex_zen_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_yandex_zen_user_profile) | failed from github CI infra IPs |
+25 | Yandex messenger search API |  |  |
+26 | Yandex messenger profile API |  |  |
+27 | Yandex Bugbounty user profile |  |  |
+28 | Yandex O | [yandex_o_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_yandex_o_user_profile) | down. service no longer exists |
+29 | VK user profile foaf page | [vk_foaf](https://github.com/soxoj/socid-extractor/search?q=test_vk_foaf), [vk_user_profile_no_username](https://github.com/soxoj/socid-extractor/search?q=test_vk_user_profile_no_username) | VK foaf.php returns empty body for unauthenticated clients (2026), VK web is SPA; static fetch has no embed with ownerId (2026) |
+30 | VK user profile | [vk_blocked_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_vk_blocked_user_profile), [vk_closed_user_profile](https://github.com/soxoj/socid-extractor/search?q=test_vk_closed_user_profile), [vk_user_profile_full](https://github.com/soxoj/socid-extractor/search?q=test_vk_user_profile_full), [vk_user_profile_no_username](https://github.com/soxoj/socid-extractor/search?q=test_vk_user_profile_no_username) | broken, VK web is SPA; static fetch has no embed with ownerId (2026), VK web is SPA; static fetch has no embed with ownerId (2026), VK web is SPA; static fetch has no embed with ownerId (2026) |
+31 | VK closed user profile |  |  |
+32 | VK blocked user profile |  |  |
+33 | Gravatar | [gravatar](https://github.com/soxoj/socid-extractor/search?q=test_gravatar) | broken |
+34 | Instagram | [instagram](https://github.com/soxoj/socid-extractor/search?q=test_instagram) | requests from GitHub Actions CI servers are blocked, broken. needs deeper rework |
+35 | Instagram API | [instagram_api](https://github.com/soxoj/socid-extractor/search?q=test_instagram_api) | requests from GitHub Actions CI servers are blocked |
+36 | Instagram page JSON | [instagram](https://github.com/soxoj/socid-extractor/search?q=test_instagram) | requests from GitHub Actions CI servers are blocked, broken. needs deeper rework |
+37 | Instagram GraphQL | [instagram_graphql_bio_links_and_tagged_usernames](https://github.com/soxoj/socid-extractor/search?q=test_instagram_graphql_bio_links_and_tagged_usernames), [instagram_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_instagram_graphql_e2e) | anti-bot / captcha / rate limiting from the site, requests from GitHub Actions CI servers are blocked |
+38 | Spotify API |  |  |
+39 | EyeEm | [eyeem](https://github.com/soxoj/socid-extractor/search?q=test_eyeem) | EyeEm returns 403 for automated clients (2026) |
+40 | Medium RSS |  |  |
+41 | Medium | [medium](https://github.com/soxoj/socid-extractor/search?q=test_medium) |  |
+42 | Odnoklassniki | [odnoklassniki](https://github.com/soxoj/socid-extractor/search?q=test_odnoklassniki) |  |
+43 | Habrahabr HTML (old) |  |  |
+44 | Habrahabr JSON | [habr](https://github.com/soxoj/socid-extractor/search?q=test_habr), [habr_no_image](https://github.com/soxoj/socid-extractor/search?q=test_habr_no_image) | requests from GitHub Actions CI servers are blocked, requests from GitHub Actions CI servers are blocked |
+45 | My Mail.ru |  |  |
+46 | Behance | [behance](https://github.com/soxoj/socid-extractor/search?q=test_behance) | broken |
+47 | Blogger | [blogger](https://github.com/soxoj/socid-extractor/search?q=test_blogger) | Failed in GitHub CI |
+48 | D3.ru | [d3](https://github.com/soxoj/socid-extractor/search?q=test_d3) | requests from GitHub Actions CI servers are blocked |
+49 | Gitlab |  |  |
+50 | 500px userByUsername API |  |  |
+51 | 500px GraphQL API | [500px](https://github.com/soxoj/socid-extractor/search?q=test_500px) |  |
+52 | Google Document API | [google_documents](https://github.com/soxoj/socid-extractor/search?q=test_google_documents) |  |
+53 | Google Document |  |  |
+54 | Google Maps contributions |  |  |
+55 | YouTube ytInitialData |  |  |
+56 | Youtube Channel |  |  |
+57 | Bitbucket | [bitbucket](https://github.com/soxoj/socid-extractor/search?q=test_bitbucket) | Bitbucket UI/embed changed; test user URL 404 (2026) |
+58 | Pinterest profile/board page | [pinterest_account](https://github.com/soxoj/socid-extractor/search?q=test_pinterest_account) |  |
+59 | Reddit | [reddit](https://github.com/soxoj/socid-extractor/search?q=test_reddit) | broken |
+60 | Steam | [steam](https://github.com/soxoj/socid-extractor/search?q=test_steam) | cloudflare |
+61 | Steam Community Group |  |  |
+62 | Steam Addiction |  |  |
+63 | Stack Exchange API | [stack_exchange_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_stack_exchange_api_e2e) | anti-bot / captcha / rate limiting from the site |
+64 | Stack Overflow & similar |  |  |
+65 | SoundCloud | [soundcloud](https://github.com/soxoj/socid-extractor/search?q=test_soundcloud) | SoundCloud returns 403 / empty embed for automated clients (2026) |
+66 | TikTok | [tiktok](https://github.com/soxoj/socid-extractor/search?q=test_tiktok), [tiktok_hydration_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tiktok_hydration_e2e) | requests from GitHub Actions CI servers are blocked, requests from GitHub Actions CI servers are blocked |
+67 | TikTok (legacy SIGI_STATE) | [tiktok_hydration_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tiktok_hydration_e2e) | requests from GitHub Actions CI servers are blocked |
+68 | Picsart API | [picsart_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_picsart_api_e2e) | requests from GitHub Actions CI servers are blocked |
+69 | VC.ru |  |  |
+70 | LiveJournal | [livejournal](https://github.com/soxoj/socid-extractor/search?q=test_livejournal) | requests from GitHub Actions CI servers are blocked |
+71 | MySpace | [myspace](https://github.com/soxoj/socid-extractor/search?q=test_myspace) | doesnt work without proxy, 503 error |
+72 | Keybase API |  |  |
+73 | Wikimapia |  |  |
+74 | Vimeo HTML | [vimeo_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_vimeo_html_e2e) | requests from GitHub Actions CI servers are blocked |
+75 | Vimeo GraphQL API |  |  |
+76 | DeviantArt | [deviantart](https://github.com/soxoj/socid-extractor/search?q=test_deviantart) | it works but is skipped for the sake of successful tests |
+77 | mssg.me | [mssg_me](https://github.com/soxoj/socid-extractor/search?q=test_mssg_me) | broken |
+78 | Telegram | [telegram](https://github.com/soxoj/socid-extractor/search?q=test_telegram) |  |
+79 | BuzzFeed | [buzzfeed](https://github.com/soxoj/socid-extractor/search?q=test_buzzfeed) | requests from GitHub Actions CI servers are blocked |
+80 | Linktree | [linktree](https://github.com/soxoj/socid-extractor/search?q=test_linktree) | broken |
+81 | Twitch | [twitch](https://github.com/soxoj/socid-extractor/search?q=test_twitch) | broken |
+82 | vBulletinEngine |  |  |
+83 | Tumblr (default theme) |  |  |
+84 | 1x.com |  |  |
+85 | Last.fm | [last_fm](https://github.com/soxoj/socid-extractor/search?q=test_last_fm) | requests from GitHub Actions CI servers are blocked |
+86 | Ask.fm | [ask_fm](https://github.com/soxoj/socid-extractor/search?q=test_ask_fm) | broken |
+87 | Launchpad | [launchpad](https://github.com/soxoj/socid-extractor/search?q=test_launchpad) | requests from GitHub Actions CI servers are blocked |
+88 | Xakep.ru |  |  |
+89 | Tproger.ru | [tproger_ru](https://github.com/soxoj/socid-extractor/search?q=test_tproger_ru) | no more author pages for now |
+90 | Jsfiddle.net |  |  |
+91 | Disqus API | [disqus_api](https://github.com/soxoj/socid-extractor/search?q=test_disqus_api) |  |
+92 | uCoz-like profile page |  |  |
+93 | uID.me |  |  |
+94 | tapd | [tapd](https://github.com/soxoj/socid-extractor/search?q=test_tapd) | down |
+95 | freelancer.com |  |  |
+96 | Yelp | [yelp_userid](https://github.com/soxoj/socid-extractor/search?q=test_yelp_userid), [yelp_username](https://github.com/soxoj/socid-extractor/search?q=test_yelp_username) | broken, broken |
+97 | Trello API | [trello](https://github.com/soxoj/socid-extractor/search?q=test_trello) |  |
+98 | Weibo API | [weibo_api](https://github.com/soxoj/socid-extractor/search?q=test_weibo_api), [weibo_api_by_id](https://github.com/soxoj/socid-extractor/search?q=test_weibo_api_by_id) | requests from GitHub Actions CI servers are blocked, requests from GitHub Actions CI servers are blocked |
+99 | Weibo | [weibo](https://github.com/soxoj/socid-extractor/search?q=test_weibo) | needs rework, cookies are required to get content, requests from GitHub Actions CI servers are blocked |
+100 | ICQ | [icq](https://github.com/soxoj/socid-extractor/search?q=test_icq) | broken forever |
+101 | Pastebin | [pastebin](https://github.com/soxoj/socid-extractor/search?q=test_pastebin) |  |
+102 | Periscope |  |  |
+103 | Imgur API | [imgur_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_imgur_api_e2e) |  |
+104 | PayPal |  |  |
+105 | Tinder | [tinder](https://github.com/soxoj/socid-extractor/search?q=test_tinder) | broken |
+106 | ifunny.co | [ifunny_co](https://github.com/soxoj/socid-extractor/search?q=test_ifunny_co) |  |
+107 | Wattpad API | [wattpad_api](https://github.com/soxoj/socid-extractor/search?q=test_wattpad_api) | Wattpad API endpoint is unavailable / unstable from CI (2026) |
+108 | Kik | [kik](https://github.com/soxoj/socid-extractor/search?q=test_kik) | broken |
+109 | Docker Hub API | [docker_hub_api](https://github.com/soxoj/socid-extractor/search?q=test_docker_hub_api) |  |
+110 | Mixcloud API | [mixcloud_api](https://github.com/soxoj/socid-extractor/search?q=test_mixcloud_api) |  |
+111 | binarysearch API | [binarysearch_api](https://github.com/soxoj/socid-extractor/search?q=test_binarysearch_api) | down |
+112 | pr0gramm API | [pr0gramm_api](https://github.com/soxoj/socid-extractor/search?q=test_pr0gramm_api) |  |
+113 | Aparat API | [aparat_api](https://github.com/soxoj/socid-extractor/search?q=test_aparat_api) | broken |
+114 | UnstoppableDomains |  |  |
+115 | memory.lol | [memory_lol](https://github.com/soxoj/socid-extractor/search?q=test_memory_lol) |  |
+116 | Duolingo API | [duolingo_api](https://github.com/soxoj/socid-extractor/search?q=test_duolingo_api) |  |
+117 | TwitchTracker |  |  |
+118 | Chess.com API | [chess_com_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_chess_com_api_e2e) |  |
+119 | Roblox user API | [roblox_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_roblox_api_e2e) |  |
+120 | Roblox username lookup API |  |  |
+121 | MyAnimeList profile |  |  |
+122 | XVideos profile |  |  |
+123 | lnk.bio |  |  |
+124 | Wikipedia user API |  |  |
+125 | Fandom MediaWiki API |  |  |
+126 | Substack public profile API |  |  |
+127 | Lesswrong GraphQL API |  |  |
+128 | hashnode GraphQL API |  |  |
+129 | Rarible API |  |  |
+130 | CSSBattle |  |  |
+131 | Max (max.ru) profile |  |  |
+132 | Bluesky API |  |  |
+133 | Scratch API |  |  |
+134 | DailyMotion API |  |  |
+135 | SlideShare |  |  |
+136 | WordPress.org Profile |  |  |
+137 | Weebly |  |  |
+138 | Calendly |  |  |
+139 | Google Play Developer |  |  |
+140 | Amazon Author |  |  |
+141 | Habr |  |  |
+142 | Taplink |  |  |
+143 | Product Hunt |  |  |
+144 | Chess.com HTML | [chess_com_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_chess_com_html_e2e) | chess.com HTML endpoint times out from CI (2026) |
+145 | Roblox HTML | [roblox_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_roblox_html_e2e) |  |
+146 | LeetCode GraphQL | [leetcode_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_leetcode_graphql_e2e) |  |
+147 | Boosty API | [boosty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_boosty_api_e2e) |  |
+148 | Threads |  |  |
+149 | Smule |  |  |
+150 | Warpcast API | [warpcast_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_warpcast_api_e2e) |  |
+151 | Paragraph API | [paragraph_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_paragraph_api_e2e) |  |
+152 | Fragment | [fragment_e2e](https://github.com/soxoj/socid-extractor/search?q=test_fragment_e2e) |  |
+153 | Tonometerbot | [tonometerbot_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tonometerbot_e2e) | anti-bot / captcha / rate limiting from the site |
+154 | Spatial | [spatial_e2e](https://github.com/soxoj/socid-extractor/search?q=test_spatial_e2e) | requests from GitHub Actions CI servers are blocked |
+155 | OpenSea |  |  |
+156 | Hive Blog |  |  |
+157 | ORCID API |  |  |
+158 | OpenAlex Authors API |  |  |
+159 | arXiv author page |  |  |
+160 | DBLP person record |  |  |
+161 | Scholia author profile |  |  |
+162 | BuyMeACoffee | [buymeacoffee](https://github.com/soxoj/socid-extractor/search?q=test_buymeacoffee) |  |
+163 | Discourse API | [discourse_api](https://github.com/soxoj/socid-extractor/search?q=test_discourse_api) |  |
+164 | Snapchat | [snapchat](https://github.com/soxoj/socid-extractor/search?q=test_snapchat) |  |
+165 | Bio Site | [bio_site](https://github.com/soxoj/socid-extractor/search?q=test_bio_site) |  |
+166 | Faceit API | [faceit_api](https://github.com/soxoj/socid-extractor/search?q=test_faceit_api) |  |
+167 | Fansly API | [fansly_api](https://github.com/soxoj/socid-extractor/search?q=test_fansly_api) |  |
+168 | Codewars API |  |  |
+169 | Minds API |  |  |
+170 | HackerNoon API |  |  |
+171 | Polar API |  |  |
+172 | thanks.dev API |  |  |
+173 | Matrix profile API |  |  |
+174 | osu! | [osu](https://github.com/soxoj/socid-extractor/search?q=test_osu) |  |
+175 | Lens (Hey/Orb/Buttrfly) account | [lens_account](https://github.com/soxoj/socid-extractor/search?q=test_lens_account), [lens_account_absent](https://github.com/soxoj/socid-extractor/search?q=test_lens_account_absent) |  |
+176 | HuggingFace API | [huggingface_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_huggingface_api_e2e) |  |
+177 | HackerNews | [hackernews](https://github.com/soxoj/socid-extractor/search?q=test_hackernews) |  |
+178 | Teletype | [teletype](https://github.com/soxoj/socid-extractor/search?q=test_teletype) |  |
+179 | GDBrowser API | [gdbrowser_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_gdbrowser_api_e2e) |  |
+180 | StreamElements API | [streamelements_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamelements_api_e2e) |  |
+181 | Streamlabs API | [streamlabs_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamlabs_api_e2e) |  |
+182 | Donatty API | [donatty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_donatty_api_e2e) |  |
+183 | VisnessCard API | [visnesscard_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_visnesscard_api_e2e) | requests from GitHub Actions CI servers are blocked |
+184 | Codeforces API |  |  |
+185 | Discogs API |  |  |
+186 | iNaturalist API |  |  |
+187 | Pronouny API |  |  |
+188 | Zepeto API |  |  |
+189 | OnlyFans API |  |  |
+190 | eToro API |  |  |
+191 | Gettr API |  |  |
+192 | Habbo API |  |  |
+193 | Hackadvisor API |  |  |
+194 | Pillowfort JSON API |  |  |
+195 | Scored API |  |  |
+196 | YesWeHack API |  |  |
+197 | Destream API |  |  |
+198 | Tipeeestream API |  |  |
+199 | Komi API |  |  |
+200 | Cropty API |  |  |
+201 | Redgifs API |  |  |
+202 | Tappy API |  |  |
+203 | Komoot API |  |  |
+204 | Tapitag API |  |  |
+205 | Vivino API |  |  |
+206 | Google Scholar |  |  |
+207 | Snapchat profile |  |  |
+208 | Flipboard profile |  |  |
+209 | Clubhouse profile |  |  |
+210 | Coda.io profile |  |  |
+211 | Poe.com profile |  |  |
+212 | Gumroad profile |  |  |
+213 | Mastodon HTML profile |  |  |
+214 | Discourse HTML profile | [discourse_html_profile](https://github.com/soxoj/socid-extractor/search?q=test_discourse_html_profile) |  |
+215 | Mastodon API |  |  |
+216 | FL.ru |  |  |
+217 | Manifold Markets |  |  |
+218 | VSCO |  |  |
+219 | Mojang API |  |  |
+220 | OP.GG |  |  |
+221 | coder.social |  |  |
+222 | GOG |  |  |
+223 | Kick API |  |  |
+224 | Academia.edu |  |  |
+225 | TradingView |  |  |
+226 | Geocaching |  |  |
+227 | Rutracker |  |  |
+228 | Weburg |  |  |
+229 | Pokemon Showdown |  |  |
+230 | ImageShack |  |  |
+231 | Replit |  |  |
+232 | Itch.io |  |  |
+233 | Giphy |  |  |
+234 | Wattpad HTML profile |  |  |
+235 | Venmo |  |  |
+236 | Tumblr blog |  |  |
+237 | Drive2.ru |  |  |
+238 | Lichess API |  |  |
+239 | Hackerrank API |  |  |
+240 | Kongregate API |  |  |
+241 | WordPress.com site API |  |  |
+242 | Codecademy profile |  |  |
+243 | About.me profile |  |  |
+244 | Fur Affinity profile |  |  |
+245 | Pikabu profile |  |  |
+246 | Codepen profile |  |  |
+247 | Letterboxd profile |  |  |
+248 | Gitee profile |  |  |
+249 | Slack workspace |  |  |
+250 | Instructables member |  |  |
+251 | Envato Author profile |  |  |
+252 | Kwork freelancer |  |  |
+253 | Freesound user |  |  |
+254 | Star Citizen citizen |  |  |
+255 | Dribbble profile |  |  |
+256 | Depop shop |  |  |
+257 | ModDB member |  |  |
+258 | Xbox Gamertag |  |  |
+259 | DonationAlerts streamer |  |  |
+260 | CCM profile |  |  |
+261 | Wikidot user |  |  |
+262 | Couchsurfing person |  |  |
+263 | ReverbNation artist |  |  |
 
-The table has been updated at 2026-09-06 17:32:40.442453 UTC
+The table has been updated at 2026-09-07 21:26:08.324494 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -373,6 +373,85 @@ _MASTODON_INSTANCES = [
 ]
 
 
+_PATREON_RSC_CHUNK_RE = re.compile(r'self\.__next_f\.push\(\[1,("(?:[^"\\]|\\.)*")\]\)')
+
+
+def _patreon_rsc_deref(rsc, obj):
+    """Resolve `"$<row>"` placeholders to the RSC text rows they point at.
+
+    Long strings (a campaign summary, say) are not inlined — the object holds a
+    reference like `"$5f"` and that row carries the text. Row ids are hex, so a
+    decimal-only pattern silently leaves anything past row 9 unresolved. Only
+    text rows (`T`) are resolved; the payload length in their header is counted
+    in UTF-8 bytes, not characters.
+    """
+    raw = rsc.encode('utf-8')
+
+    def resolve(match):
+        row = re.search(rb'(?:^|\n)' + match.group(1).encode() + rb':T([0-9a-f]+),', raw)
+        if not row:
+            return match.group(0)
+        length = int(row.group(1), 16)
+        return json.dumps(raw[row.end():row.end() + length].decode('utf-8', 'replace'))
+
+    return re.sub(r'"\$([0-9a-f]+)"', resolve, obj)
+
+
+def _patreon_rsc_bootstrap(page):
+    """Pull the `pageBootstrap` object out of a Patreon App Router page.
+
+    Those profiles carry no __NEXT_DATA__ — the same payload arrives as escaped
+    JSON inside `self.__next_f.push([1,"..."])` chunks, so the chunks are decoded,
+    joined, and the object is cut out by brace matching. Returns a JSON string
+    for the extract_json pipeline, '{}' when the marker is absent.
+    """
+    rsc = ''.join(json.loads(c) for c in _PATREON_RSC_CHUNK_RE.findall(page))
+    marker = rsc.find('"pageBootstrap":')
+    if marker < 0:
+        return '{}'
+    start = rsc.find('{', marker + len('"pageBootstrap":'))
+    depth, in_string, escaped = 0, False, False
+    for i in range(start, len(rsc)):
+        char = rsc[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == '\\':
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char == '{':
+            depth += 1
+        elif char == '}':
+            depth -= 1
+            if depth == 0:
+                return _patreon_rsc_deref(rsc, rsc[start:i + 1])
+    return '{}'
+
+
+def _patreon_user(bootstrap):
+    """The `user` entry of a campaign's `included` list — its position varies."""
+    return next((i for i in bootstrap['campaign']['included'] if i.get('type') == 'user'), {})
+
+
+# Shared by both Patreon schemes below: the campaign payload has the same shape
+# whether it comes from __NEXT_DATA__ or from the App Router RSC stream.
+_PATREON_FIELDS = {
+    'patreon_id': lambda x: _patreon_user(x)['id'],
+    'patreon_username': lambda x: _patreon_user(x)['attributes']['vanity'],
+    'fullname': lambda x: _patreon_user(x)['attributes']['full_name'],
+    'links': lambda x: [y['attributes'].get('external_profile_url') for y in x['campaign']['included'] if
+                        y['attributes'].get('app_name')],
+    'image': lambda x: x['campaign']['data']['attributes']['avatar_photo_url'],
+    'image_bg': lambda x: x['campaign']['data']['attributes']['cover_photo_url'],
+    'is_nsfw': lambda x: x['campaign']['data']['attributes']['is_nsfw'],
+    'created_at': lambda x: x['campaign']['data']['attributes']['published_at'],
+    'bio': lambda x: x['campaign']['data']['attributes']['summary'],
+}
+
+
 schemes = {
     # IMPORTANT: extract() returns the FIRST matching scheme.
     # More specific schemes (more/stricter flags) must come BEFORE
@@ -566,20 +645,27 @@ schemes = {
     'Patreon': {
         'url_hints': ('patreon.com',),
         'flags': ['www.patreon.com/api', 'pledge_url'],
-        'regex': r'Object.assign\(window.patreon.bootstrap, ([\s\S]*)\);[\s\S]*Object.assign\(window.patreon.campaignFeatures, {}\);',
+        # Patreon moved to Next.js: the old `window.patreon.bootstrap` assignment
+        # is gone, the same payload now sits in __NEXT_DATA__ under pageBootstrap.
+        'regex': r'<script id="__NEXT_DATA__"[^>]*>([\s\S]+?)</script>',
         'extract_json': True,
-        'fields': {
-            'patreon_id': lambda x: x['campaign']['included'][0]['id'],
-            'patreon_username': lambda x: x['campaign']['included'][0]['attributes']['vanity'],
-            'fullname': lambda x: x['campaign']['included'][0]['attributes']['full_name'],
-            'links': lambda x: [y['attributes'].get('external_profile_url') for y in x['campaign']['included'] if
-                                y['attributes'].get('app_name')],
-            'image': lambda x: x['campaign']['data']['attributes']['avatar_photo_url'],
-            'image_bg': lambda x: x['campaign']['data']['attributes']['cover_photo_url'],
-            'is_nsfw': lambda x: x['campaign']['data']['attributes']['is_nsfw'],
-            'created_at': lambda x: x['campaign']['data']['attributes']['published_at'],
-            'bio': lambda x: x['campaign']['data']['attributes']['summary'],
-        }
+        'transforms': [
+            json.loads,
+            lambda x: safe_deep_get(x, 'props', 'pageProps', 'bootstrapEnvelope', 'pageBootstrap', default={}),
+            json.dumps,
+        ],
+        'fields': _PATREON_FIELDS,
+    },
+    # Patreon is mid-migration: App Router profiles (e.g. /kurzgesagt) ship no
+    # __NEXT_DATA__ at all, the same pageBootstrap arrives in an RSC stream.
+    'Patreon RSC': {
+        'url_hints': ('patreon.com',),
+        # RSC payloads are escaped, so the raw body has \"pageBootstrap\", not "pageBootstrap"
+        'flags': ['self.__next_f', 'pageBootstrap', 'pledge_url'],
+        'regex': r'^([\s\S]+)$',
+        'extract_json': True,
+        'transforms': [_patreon_rsc_bootstrap],
+        'fields': _PATREON_FIELDS,
     },
     'Flickr': {
         'url_hints': ('flickr.com',),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -860,7 +860,7 @@ def test_mssg_me():
     assert info.get('messenger_values') == "['+77026924715', 'adamcigelnik']"
 
 
-@pytest.mark.skip(reason="broken")
+@pytest.mark.rate_limited  # Cloudflare challenges datacenter IPs; needs a residential proxy
 def test_patreon():
     info = extract(parse('https://www.patreon.com/annetlovart')[0])
 
@@ -874,6 +874,21 @@ def test_patreon():
     assert 'image_bg' in info
     assert info.get('created_at') == '2020-04-19T16:29:11.000+00:00'
     assert 'bio' in info
+
+
+@pytest.mark.rate_limited  # Cloudflare challenges datacenter IPs; needs a residential proxy
+def test_patreon_rsc():
+    """Patreon RSC"""
+    # App Router profile: no __NEXT_DATA__, payload comes from the RSC stream.
+    info = extract(parse('https://www.patreon.com/kurzgesagt')[0])
+
+    assert info.get('patreon_id') == '43579'
+    assert info.get('patreon_username') == 'Kurzgesagt'
+    assert info.get('is_nsfw') == 'False'
+    assert info.get('created_at') == '2013-08-30T16:09:54.000+00:00'
+    assert 'https://www.instagram.com/kurzgesagt' in info.get('links', '')
+    # a "$38"-style RSC reference must be resolved to the real summary
+    assert info.get('bio', '').startswith('<p ')
 
 
 @pytest.mark.github_failed

--- a/tests/test_socid_improvements.py
+++ b/tests/test_socid_improvements.py
@@ -1387,6 +1387,20 @@ def test_discourse_html_only_fires_on_a_profile():
     assert extract(deny) == {}
 
 
+def test_patreon_rsc_deref_reads_hex_row_ids():
+    """Patreon's RSC row ids are hex — a decimal pattern quietly loses row 10 and up."""
+    from socid_extractor.schemes import _patreon_rsc_deref
+
+    rsc = '2:{"a":1}\n5f:Tb,hello there\n60:T5,short\n'
+
+    assert _patreon_rsc_deref(rsc, '{"bio":"$5f"}') == '{"bio":"hello there"}'
+    assert _patreon_rsc_deref(rsc, '{"bio":"$60"}') == '{"bio":"short"}'
+    # a reference to a row that isn't there stays as it is, rather than blowing up
+    assert _patreon_rsc_deref(rsc, '{"bio":"$ff"}') == '{"bio":"$ff"}'
+    # and "$undefined" and friends are not row references at all
+    assert _patreon_rsc_deref(rsc, '{"bio":"$undefined"}') == '{"bio":"$undefined"}'
+
+
 def test_no_flag_subset_shadows():
     """Detect scheme pairs where one's flags are a subset of another's.
 


### PR DESCRIPTION
The README example returns `{}` today (#278). The scheme still looked for `window.patreon.bootstrap`, which Patreon dropped when it moved to Next.js.

The campaign object is still served, in two shapes. Older profiles keep it in `__NEXT_DATA__`; newer ones like `/kurzgesagt` have no `__NEXT_DATA__` at all and stream it in RSC chunks, where long strings are held back in separate rows and referenced as `"$5f"`. Two schemes now, sharing one field map. Row ids are hex, which is worth saying out loud: the first version of this read them as decimal and worked purely because the summary happened to sit in row 38.

Also fixes the profile being taken as `campaign.included[0]` — on App Router pages that slot holds a media entry, so the ids came out wrong. It matches on `type == 'user'` now.

`test_patreon` is marked `rate_limited` rather than skipped as broken: extraction works, but Cloudflare challenges datacenter IPs, so it needs a residential exit. Both e2e tests were run through one and pass. Since CI skips them, the hex dereferencing has an offline test of its own.
