### PR TITLE
Install as socid-extractor too, not just socid_extractor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ Funding = "https://www.patreon.com/soxoj"
 [project.scripts]
 # Run with: socid_extractor <url>
 socid_extractor = "socid_extractor.cli:run"
+# The package installs as socid-extractor and the repo is named that way too,
+# so that is what people type. The import name has to keep the underscore.
+socid-extractor = "socid_extractor.cli:run"
 
 [tool.setuptools.dynamic]
 version = {attr = "socid_extractor.__version__"}


### PR DESCRIPTION
The project answers to three names: `pip install socid-extractor`, `github.com/soxoj/socid-extractor`, and `import socid_extractor`. Only the last one has to keep the underscore — Python has no say in what an entry point is called, and this one inherited the underscore by accident. So the command a newcomer types after installing is exactly the one that doesn't exist.

Declaring both entry points costs one line and they call the same function. The docs go on showing `socid_extractor`, so nothing changes for anyone already using it.
