### PR TITLE
XenForo: one scheme for all 319 forums in maigret's database

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -266,5 +266,6 @@
 261 | Wikidot user |  |  |
 262 | Couchsurfing person |  |  |
 263 | ReverbNation artist |  |  |
+264 | XenForo | [xenforo](https://github.com/soxoj/socid-extractor/search?q=test_xenforo) |  |
 
-The table has been updated at 2026-09-07 21:26:08.324494 UTC
+The table has been updated at 2026-09-07 22:00:38.122362 UTC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ Funding = "https://www.patreon.com/soxoj"
 [project.scripts]
 # Run with: socid_extractor <url>
 socid_extractor = "socid_extractor.cli:run"
+# The package installs as socid-extractor and the repo is named that way too,
+# so that is what people type. The import name has to keep the underscore.
+socid-extractor = "socid_extractor.cli:run"
 
 [tool.setuptools.dynamic]
 version = {attr = "socid_extractor.__version__"}

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -252,6 +252,51 @@ def _search_group(pattern, text, group=1):
     match = re.search(pattern, text or '')
     return match.group(group) if match else None
 
+def _xenforo_profile(page):
+    """Read a XenForo member page, which has no API behind it.
+
+    The forum answers /members/?username=<name> with a redirect to the profile,
+    and the profile carries the numeric id in two places. og:url is the one to
+    trust: it survives even the login wall many instances put in front of member
+    pages, and it is what tells a profile apart from the member listing a failed
+    search falls back to — that listing is full of other people's data-user-id
+    attributes.
+
+    Labels like "Messages" and "Joined" are localised, so nothing is read by
+    them: the counters are reached through the links they wrap, and the two
+    dates are the first two <time> elements of the member header, in order.
+    Those dates come rendered in the viewer's timezone, so the offset on them
+    depends on where the request came from.
+    """
+    def find(pattern):
+        match = re.search(pattern, page)
+        return match.group(1) if match else None
+
+    member = re.search(r'og:url"\s+content="[^"]*/members/([^/"]+)\.(\d+)/', page)
+    if member:
+        uid, username = member.group(2), unquote(member.group(1))
+    elif 'memberHeader' in page:
+        # a profile that ships no og:url — take the id off the header instead
+        uid, username = find(r'data-user-id="(\d+)"'), None
+    else:
+        return '{}'
+
+    def digits(value):
+        return re.sub(r'[^0-9]', '', value) or None if value else None
+
+    times = re.findall(r'<time[^>]*datetime="([^"]+)"', page)
+    return json.dumps({
+        'uid': uid,
+        'username': username,
+        'image': find(r'<img[^>]+src="([^"]*/avatars/[^"]+)"'),
+        'created_at': times[0] if times else None,
+        'latest_activity_at': times[1] if len(times) > 1 else None,
+        # counters come out of the page grouped, as "9,193"
+        'posts_count': digits(find(r'search/member\?user_id=\d+"[^>]*>\s*([\d,.\s]+?)\s*<')),
+        'xenforo_points': digits(find(r'/trophies"[^>]*>\s*([\d,.\s]+?)\s*<')),
+    })
+
+
 def _discourse_html_profile(page):
     """Pull what a Discourse profile page still carries in its server-rendered HTML.
 
@@ -5457,6 +5502,23 @@ schemes = {
             'fullname': lambda x: _meta_re(x, 'og:title', r'^(.+?)(?:\s*\|\s*)'),
             'bio': lambda x: _meta(x, 'og:description'),
             'image': lambda x: (lambda v: v if v and 'rn-logo' not in (v or '') else None)(_meta(x, 'og:image')),
+        },
+    },
+    # XenForo has no public API — everything comes off the member page, and one
+    # scheme covers every instance of it.
+    'XenForo': {
+        'flags': ['data-user-id="', '/members/'],
+        'regex': r'^([\s\S]+)$',
+        'extract_json': True,
+        'transforms': [_xenforo_profile],
+        'fields': {
+            'uid': lambda x: x.get('uid'),
+            'username': lambda x: x.get('username'),
+            'image': lambda x: x.get('image'),
+            'created_at': lambda x: x.get('created_at'),
+            'latest_activity_at': lambda x: x.get('latest_activity_at'),
+            'posts_count': lambda x: x.get('posts_count'),
+            'xenforo_points': lambda x: x.get('xenforo_points'),
         },
     },
 }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1817,3 +1817,15 @@ def test_discourse_html_profile():
     assert info.get('username') == 'hugovk'
     assert info.get('bio')
     assert 'user_avatar' in info.get('image', '')
+
+
+def test_xenforo():
+    """XenForo"""
+    # the URL shape maigret stores: a member search that redirects to the profile
+    info = extract(parse('https://nullcave.club/members/?username=lomba_ii')[0])
+
+    assert info.get('uid') == '36147'
+    assert info.get('username') == 'lomba_ii'
+    # XenForo renders times in the viewer's timezone, so only the date is stable
+    assert info.get('created_at', '').startswith('2024-01-3')
+    assert info.get('posts_count', '').isdigit()

--- a/tests/test_socid_improvements.py
+++ b/tests/test_socid_improvements.py
@@ -1435,6 +1435,28 @@ def test_patreon_rsc_deref_reads_hex_row_ids():
     assert _patreon_rsc_deref(rsc, '{"bio":"$undefined"}') == '{"bio":"$undefined"}'
 
     
+def test_xenforo_ignores_the_member_listing():
+    """A failed member search falls back to a listing full of other people's ids."""
+    header = ('<meta property="og:url" content="https://forum.example/members/manumuskin.35/" />'
+              '<span class="username" data-user-id="35">manumuskin</span>'
+              '<div class="memberHeader-blurb"><time datetime="2003-07-20T18:23:00-0400"></time>'
+              '<time datetime="2026-09-07T16:59:37-0400"></time></div>'
+              '<a href="/search/member?user_id=35">9,193</a>')
+    profile = extract(header)
+
+    assert profile.get('uid') == '35'
+    assert profile.get('username') == 'manumuskin'
+    assert profile.get('posts_count') == '9193'
+    assert profile.get('created_at') == '2003-07-20T18:23:00-0400'
+    assert profile.get('latest_activity_at') == '2026-09-07T16:59:37-0400'
+
+    # the listing carries member cards, so data-user-id is there — but it belongs
+    # to whoever the forum felt like showing, and og:url points at the listing
+    listing = ('<meta property="og:url" content="https://forum.example/members/" />'
+               '<a href="/members/someone-else.4242/" data-user-id="4242">Someone Else</a>')
+    assert extract(listing) == {}
+
+
 def test_no_flag_subset_shadows():
     """Detect scheme pairs where one's flags are a subset of another's.
 


### PR DESCRIPTION
XenForo is the second-largest engine in maigret's site database after uCoz, and nothing here parsed it. There is no API, so this reads the member page maigret already fetches.

The id comes from `og:url`, not from `data-user-id`. A member search that finds nobody falls back to the member listing, which is full of other people's `data-user-id` attributes — a scheme keying on that would confidently report a stranger. `og:url` also survives the login wall many instances put in front of member pages, so an id and a name still come out when nothing else does.

No field is read by its label. `Messages` and `Joined` come localised in at least five languages, so the counters are reached through the links they wrap and the two dates are the first two `<time>` elements of the header. Those are rendered in the viewer's timezone, which is why the test only pins the date.

Measured on 40 random XenForo entries from the database: 37 answered, 18 extracted, and all 18 usernames matched the one searched for. The rest were Cloudflare challenges, login walls without `og:url`, and dead hosts.
