### PR TITLE
MediaWiki: cover every wiki, not just Wikipedia

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -268,4 +268,4 @@
 263 | Couchsurfing person |  |  |
 264 | ReverbNation artist |  |  |
 
-The table has been updated at 2026-09-07 23:21:47.906618 UTC
+The table has been updated at 2026-09-07 23:35:27.759116 UTC

--- a/METHODS.md
+++ b/METHODS.md
@@ -126,145 +126,146 @@
 121 | MyAnimeList profile |  |  |
 122 | XVideos profile |  |  |
 123 | lnk.bio |  |  |
-124 | Wikipedia user API |  |  |
-125 | Fandom MediaWiki API |  |  |
-126 | Substack public profile API |  |  |
-127 | Lesswrong GraphQL API |  |  |
-128 | hashnode GraphQL API |  |  |
-129 | Rarible API |  |  |
-130 | CSSBattle |  |  |
-131 | Max (max.ru) profile |  |  |
-132 | Bluesky API |  |  |
-133 | Scratch API |  |  |
-134 | DailyMotion API |  |  |
-135 | SlideShare |  |  |
-136 | WordPress.org Profile |  |  |
-137 | Weebly |  |  |
-138 | Calendly |  |  |
-139 | Google Play Developer |  |  |
-140 | Amazon Author |  |  |
-141 | Habr |  |  |
-142 | Taplink |  |  |
-143 | Product Hunt |  |  |
-144 | Chess.com HTML | [chess_com_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_chess_com_html_e2e) | chess.com HTML endpoint times out from CI (2026) |
-145 | Roblox HTML | [roblox_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_roblox_html_e2e) |  |
-146 | LeetCode GraphQL | [leetcode_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_leetcode_graphql_e2e) |  |
-147 | Boosty API | [boosty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_boosty_api_e2e) |  |
-148 | Threads |  |  |
-149 | Smule |  |  |
-150 | Warpcast API | [warpcast_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_warpcast_api_e2e) |  |
-151 | Paragraph API | [paragraph_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_paragraph_api_e2e) |  |
-152 | Fragment | [fragment_e2e](https://github.com/soxoj/socid-extractor/search?q=test_fragment_e2e) |  |
-153 | Tonometerbot | [tonometerbot_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tonometerbot_e2e) | anti-bot / captcha / rate limiting from the site |
-154 | Spatial | [spatial_e2e](https://github.com/soxoj/socid-extractor/search?q=test_spatial_e2e) | requests from GitHub Actions CI servers are blocked |
-155 | OpenSea |  |  |
-156 | Hive Blog |  |  |
-157 | ORCID API |  |  |
-158 | OpenAlex Authors API |  |  |
-159 | arXiv author page |  |  |
-160 | DBLP person record |  |  |
-161 | Scholia author profile |  |  |
-162 | BuyMeACoffee | [buymeacoffee](https://github.com/soxoj/socid-extractor/search?q=test_buymeacoffee) |  |
-163 | Discourse API | [discourse_api](https://github.com/soxoj/socid-extractor/search?q=test_discourse_api) |  |
-164 | Snapchat | [snapchat](https://github.com/soxoj/socid-extractor/search?q=test_snapchat) |  |
-165 | Bio Site | [bio_site](https://github.com/soxoj/socid-extractor/search?q=test_bio_site) |  |
-166 | Faceit API | [faceit_api](https://github.com/soxoj/socid-extractor/search?q=test_faceit_api) |  |
-167 | Fansly API | [fansly_api](https://github.com/soxoj/socid-extractor/search?q=test_fansly_api) |  |
-168 | Codewars API |  |  |
-169 | Minds API |  |  |
-170 | HackerNoon API |  |  |
-171 | Polar API |  |  |
-172 | thanks.dev API |  |  |
-173 | Matrix profile API |  |  |
-174 | osu! | [osu](https://github.com/soxoj/socid-extractor/search?q=test_osu) |  |
-175 | Lens (Hey/Orb/Buttrfly) account | [lens_account](https://github.com/soxoj/socid-extractor/search?q=test_lens_account), [lens_account_absent](https://github.com/soxoj/socid-extractor/search?q=test_lens_account_absent) |  |
-176 | HuggingFace API | [huggingface_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_huggingface_api_e2e) |  |
-177 | HackerNews | [hackernews](https://github.com/soxoj/socid-extractor/search?q=test_hackernews) |  |
-178 | Teletype | [teletype](https://github.com/soxoj/socid-extractor/search?q=test_teletype) |  |
-179 | GDBrowser API | [gdbrowser_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_gdbrowser_api_e2e) |  |
-180 | StreamElements API | [streamelements_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamelements_api_e2e) |  |
-181 | Streamlabs API | [streamlabs_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamlabs_api_e2e) |  |
-182 | Donatty API | [donatty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_donatty_api_e2e) |  |
-183 | VisnessCard API | [visnesscard_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_visnesscard_api_e2e) | requests from GitHub Actions CI servers are blocked |
-184 | Codeforces API |  |  |
-185 | Discogs API |  |  |
-186 | iNaturalist API |  |  |
-187 | Pronouny API |  |  |
-188 | Zepeto API |  |  |
-189 | OnlyFans API |  |  |
-190 | eToro API |  |  |
-191 | Gettr API |  |  |
-192 | Habbo API |  |  |
-193 | Hackadvisor API |  |  |
-194 | Pillowfort JSON API |  |  |
-195 | Scored API |  |  |
-196 | YesWeHack API |  |  |
-197 | Destream API |  |  |
-198 | Tipeeestream API |  |  |
-199 | Komi API |  |  |
-200 | Cropty API |  |  |
-201 | Redgifs API |  |  |
-202 | Tappy API |  |  |
-203 | Komoot API |  |  |
-204 | Tapitag API |  |  |
-205 | Vivino API |  |  |
-206 | Google Scholar |  |  |
-207 | Snapchat profile |  |  |
-208 | Flipboard profile |  |  |
-209 | Clubhouse profile |  |  |
-210 | Coda.io profile |  |  |
-211 | Poe.com profile |  |  |
-212 | Gumroad profile |  |  |
-213 | Mastodon HTML profile |  |  |
-214 | Discourse HTML profile | [discourse_html_profile](https://github.com/soxoj/socid-extractor/search?q=test_discourse_html_profile) |  |
-215 | Mastodon API |  |  |
-216 | FL.ru |  |  |
-217 | Manifold Markets |  |  |
-218 | VSCO |  |  |
-219 | Mojang API |  |  |
-220 | OP.GG |  |  |
-221 | coder.social |  |  |
-222 | GOG |  |  |
-223 | Kick API |  |  |
-224 | Academia.edu |  |  |
-225 | TradingView |  |  |
-226 | Geocaching |  |  |
-227 | Rutracker |  |  |
-228 | Weburg |  |  |
-229 | Pokemon Showdown |  |  |
-230 | ImageShack |  |  |
-231 | Replit |  |  |
-232 | Itch.io |  |  |
-233 | Giphy |  |  |
-234 | Wattpad HTML profile |  |  |
-235 | Venmo |  |  |
-236 | Tumblr blog |  |  |
-237 | Drive2.ru |  |  |
-238 | Lichess API |  |  |
-239 | Hackerrank API |  |  |
-240 | Kongregate API |  |  |
-241 | WordPress.com site API |  |  |
-242 | Codecademy profile |  |  |
-243 | About.me profile |  |  |
-244 | Fur Affinity profile |  |  |
-245 | Pikabu profile |  |  |
-246 | Codepen profile |  |  |
-247 | Letterboxd profile |  |  |
-248 | Gitee profile |  |  |
-249 | Slack workspace |  |  |
-250 | Instructables member |  |  |
-251 | Envato Author profile |  |  |
-252 | Kwork freelancer |  |  |
-253 | Freesound user |  |  |
-254 | Star Citizen citizen |  |  |
-255 | Dribbble profile |  |  |
-256 | Depop shop |  |  |
-257 | ModDB member |  |  |
-258 | Xbox Gamertag |  |  |
-259 | DonationAlerts streamer |  |  |
-260 | CCM profile |  |  |
-261 | Wikidot user |  |  |
-262 | Couchsurfing person |  |  |
-263 | ReverbNation artist |  |  |
+124 | MediaWiki API | [mediawiki_api](https://github.com/soxoj/socid-extractor/search?q=test_mediawiki_api) |  |
+125 | MediaWiki user page | [mediawiki_user_page](https://github.com/soxoj/socid-extractor/search?q=test_mediawiki_user_page) |  |
+126 | Fandom MediaWiki API |  |  |
+127 | Substack public profile API |  |  |
+128 | Lesswrong GraphQL API |  |  |
+129 | hashnode GraphQL API |  |  |
+130 | Rarible API |  |  |
+131 | CSSBattle |  |  |
+132 | Max (max.ru) profile |  |  |
+133 | Bluesky API |  |  |
+134 | Scratch API |  |  |
+135 | DailyMotion API |  |  |
+136 | SlideShare |  |  |
+137 | WordPress.org Profile |  |  |
+138 | Weebly |  |  |
+139 | Calendly |  |  |
+140 | Google Play Developer |  |  |
+141 | Amazon Author |  |  |
+142 | Habr |  |  |
+143 | Taplink |  |  |
+144 | Product Hunt |  |  |
+145 | Chess.com HTML | [chess_com_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_chess_com_html_e2e) | chess.com HTML endpoint times out from CI (2026) |
+146 | Roblox HTML | [roblox_html_e2e](https://github.com/soxoj/socid-extractor/search?q=test_roblox_html_e2e) |  |
+147 | LeetCode GraphQL | [leetcode_graphql_e2e](https://github.com/soxoj/socid-extractor/search?q=test_leetcode_graphql_e2e) |  |
+148 | Boosty API | [boosty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_boosty_api_e2e) |  |
+149 | Threads |  |  |
+150 | Smule |  |  |
+151 | Warpcast API | [warpcast_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_warpcast_api_e2e) |  |
+152 | Paragraph API | [paragraph_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_paragraph_api_e2e) |  |
+153 | Fragment | [fragment_e2e](https://github.com/soxoj/socid-extractor/search?q=test_fragment_e2e) |  |
+154 | Tonometerbot | [tonometerbot_e2e](https://github.com/soxoj/socid-extractor/search?q=test_tonometerbot_e2e) | anti-bot / captcha / rate limiting from the site |
+155 | Spatial | [spatial_e2e](https://github.com/soxoj/socid-extractor/search?q=test_spatial_e2e) | requests from GitHub Actions CI servers are blocked |
+156 | OpenSea |  |  |
+157 | Hive Blog |  |  |
+158 | ORCID API |  |  |
+159 | OpenAlex Authors API |  |  |
+160 | arXiv author page |  |  |
+161 | DBLP person record |  |  |
+162 | Scholia author profile |  |  |
+163 | BuyMeACoffee | [buymeacoffee](https://github.com/soxoj/socid-extractor/search?q=test_buymeacoffee) |  |
+164 | Discourse API | [discourse_api](https://github.com/soxoj/socid-extractor/search?q=test_discourse_api) |  |
+165 | Snapchat | [snapchat](https://github.com/soxoj/socid-extractor/search?q=test_snapchat) |  |
+166 | Bio Site | [bio_site](https://github.com/soxoj/socid-extractor/search?q=test_bio_site) |  |
+167 | Faceit API | [faceit_api](https://github.com/soxoj/socid-extractor/search?q=test_faceit_api) |  |
+168 | Fansly API | [fansly_api](https://github.com/soxoj/socid-extractor/search?q=test_fansly_api) |  |
+169 | Codewars API |  |  |
+170 | Minds API |  |  |
+171 | HackerNoon API |  |  |
+172 | Polar API |  |  |
+173 | thanks.dev API |  |  |
+174 | Matrix profile API |  |  |
+175 | osu! | [osu](https://github.com/soxoj/socid-extractor/search?q=test_osu) |  |
+176 | Lens (Hey/Orb/Buttrfly) account | [lens_account](https://github.com/soxoj/socid-extractor/search?q=test_lens_account), [lens_account_absent](https://github.com/soxoj/socid-extractor/search?q=test_lens_account_absent) |  |
+177 | HuggingFace API | [huggingface_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_huggingface_api_e2e) |  |
+178 | HackerNews | [hackernews](https://github.com/soxoj/socid-extractor/search?q=test_hackernews) |  |
+179 | Teletype | [teletype](https://github.com/soxoj/socid-extractor/search?q=test_teletype) |  |
+180 | GDBrowser API | [gdbrowser_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_gdbrowser_api_e2e) |  |
+181 | StreamElements API | [streamelements_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamelements_api_e2e) |  |
+182 | Streamlabs API | [streamlabs_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_streamlabs_api_e2e) |  |
+183 | Donatty API | [donatty_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_donatty_api_e2e) |  |
+184 | VisnessCard API | [visnesscard_api_e2e](https://github.com/soxoj/socid-extractor/search?q=test_visnesscard_api_e2e) | requests from GitHub Actions CI servers are blocked |
+185 | Codeforces API |  |  |
+186 | Discogs API |  |  |
+187 | iNaturalist API |  |  |
+188 | Pronouny API |  |  |
+189 | Zepeto API |  |  |
+190 | OnlyFans API |  |  |
+191 | eToro API |  |  |
+192 | Gettr API |  |  |
+193 | Habbo API |  |  |
+194 | Hackadvisor API |  |  |
+195 | Pillowfort JSON API |  |  |
+196 | Scored API |  |  |
+197 | YesWeHack API |  |  |
+198 | Destream API |  |  |
+199 | Tipeeestream API |  |  |
+200 | Komi API |  |  |
+201 | Cropty API |  |  |
+202 | Redgifs API |  |  |
+203 | Tappy API |  |  |
+204 | Komoot API |  |  |
+205 | Tapitag API |  |  |
+206 | Vivino API |  |  |
+207 | Google Scholar |  |  |
+208 | Snapchat profile |  |  |
+209 | Flipboard profile |  |  |
+210 | Clubhouse profile |  |  |
+211 | Coda.io profile |  |  |
+212 | Poe.com profile |  |  |
+213 | Gumroad profile |  |  |
+214 | Mastodon HTML profile |  |  |
+215 | Discourse HTML profile | [discourse_html_profile](https://github.com/soxoj/socid-extractor/search?q=test_discourse_html_profile) |  |
+216 | Mastodon API |  |  |
+217 | FL.ru |  |  |
+218 | Manifold Markets |  |  |
+219 | VSCO |  |  |
+220 | Mojang API |  |  |
+221 | OP.GG |  |  |
+222 | coder.social |  |  |
+223 | GOG |  |  |
+224 | Kick API |  |  |
+225 | Academia.edu |  |  |
+226 | TradingView |  |  |
+227 | Geocaching |  |  |
+228 | Rutracker |  |  |
+229 | Weburg |  |  |
+230 | Pokemon Showdown |  |  |
+231 | ImageShack |  |  |
+232 | Replit |  |  |
+233 | Itch.io |  |  |
+234 | Giphy |  |  |
+235 | Wattpad HTML profile |  |  |
+236 | Venmo |  |  |
+237 | Tumblr blog |  |  |
+238 | Drive2.ru |  |  |
+239 | Lichess API |  |  |
+240 | Hackerrank API |  |  |
+241 | Kongregate API |  |  |
+242 | WordPress.com site API |  |  |
+243 | Codecademy profile |  |  |
+244 | About.me profile |  |  |
+245 | Fur Affinity profile |  |  |
+246 | Pikabu profile |  |  |
+247 | Codepen profile |  |  |
+248 | Letterboxd profile |  |  |
+249 | Gitee profile |  |  |
+250 | Slack workspace |  |  |
+251 | Instructables member |  |  |
+252 | Envato Author profile |  |  |
+253 | Kwork freelancer |  |  |
+254 | Freesound user |  |  |
+255 | Star Citizen citizen |  |  |
+256 | Dribbble profile |  |  |
+257 | Depop shop |  |  |
+258 | ModDB member |  |  |
+259 | Xbox Gamertag |  |  |
+260 | DonationAlerts streamer |  |  |
+261 | CCM profile |  |  |
+262 | Wikidot user |  |  |
+263 | Couchsurfing person |  |  |
+264 | ReverbNation artist |  |  |
 
-The table has been updated at 2026-09-07 21:26:08.324494 UTC
+The table has been updated at 2026-09-07 23:21:47.906618 UTC

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -2853,22 +2853,59 @@ schemes = {
             'links': lambda x: x.get('links') or x.get('socialLinks'),
         },
     },
-    'Wikipedia user API': {
-        'url_hints': ('wikipedia.org',),
+    # Every MediaWiki wiki answers the same users query, so this is not just
+    # Wikipedia. What differs between them is where api.php sits. The page says
+    # so itself in <link rel="EditURI">, but a url_mutation rewrites the URL
+    # without ever seeing the page, so the candidates are offered by measured
+    # frequency — and each miss costs a request, since callers fetch them all.
+    # The pipe in usprop stays unencoded: %7C is refused outright by some wikis.
+    'MediaWiki API': {
+        'url_hints': ('wikipedia.org', '/wiki/user:', '/user:'),
         'flags': ['"batchcomplete"', '"editcount"'],
         'regex': r'^(\{[\s\S]+\})$',
         'extract_json': True,
-        'url_mutations': [{
-            'from': r'https?://(?P<lang>\w+)\.wikipedia\.org/wiki/User:(?P<username>[^/?#]+)',
-            'to': 'https://{lang}.wikipedia.org/w/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|gender&format=json',
-        }],
+        'url_mutations': [
+            {
+                # 60.5% of the wikis maigret knows keep api.php at the root
+                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{base}/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+            },
+            {
+                # another 31% under /w
+                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{base}/w/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+            },
+            {
+                # then /mediawiki
+                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{base}/mediawiki/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+            },
+            {
+                # and /wiki — the four together cover 97.6% of them
+                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{base}/wiki/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+            },
+        ],
         'fields': {
             'uid': lambda x: x.get('query', {}).get('users', [{}])[0].get('userid'),
             'username': lambda x: x.get('query', {}).get('users', [{}])[0].get('name'),
             'edit_count': lambda x: x.get('query', {}).get('users', [{}])[0].get('editcount'),
-            'created_at': lambda x: x.get('query', {}).get('users', [{}])[0].get('registration'),
+            # empty on accounts older than the field itself — that is not a
+            # failure to extract, the id is still there
+            'created_at': lambda x: x.get('query', {}).get('users', [{}])[0].get('registration') or None,
             'gender': lambda x: x.get('query', {}).get('users', [{}])[0].get('gender') if x.get('query', {}).get('users', [{}])[0].get('gender') != 'unknown' else None,
+            'groups': lambda x: ', '.join(g for g in x.get('query', {}).get('users', [{}])[0].get('groups', []) if g != '*') or None,
         },
+    },
+    # The user page itself carries no numeric id — MediaWiki keeps that behind
+    # api.php, which only the mutation above reaches. What the page does carry is
+    # wgRelevantUserName, and only when the account exists: on 14 wikis checked,
+    # every one omitted it for a name nobody had registered. So this is the whole
+    # of what maigret can read without spending a second request.
+    'MediaWiki user page': {
+        'url_hints': ('/wiki/user:', '/user:'),
+        'flags': ['"wgRelevantUserName"', 'mw-body-content'],
+        'regex': r'"wgRelevantUserName"\s*:\s*"(?P<username>[^"]+)"',
     },
     'Fandom MediaWiki API': {
         'url_hints': ('fandom.com',),

--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -2854,10 +2854,14 @@ schemes = {
         },
     },
     # Every MediaWiki wiki answers the same users query, so this is not just
-    # Wikipedia. What differs between them is where api.php sits. The page says
-    # so itself in <link rel="EditURI">, but a url_mutation rewrites the URL
-    # without ever seeing the page, so the candidates are offered by measured
-    # frequency — and each miss costs a request, since callers fetch them all.
+    # Wikipedia. What differs between them is where api.php sits, and it is not
+    # where the user page sits: on 105 of 157 wikis measured the two paths
+    # disagree, /wiki for the page and /w for the API being the classic pair.
+    # So candidates are built from the host and not from the page's own path —
+    # that alone is the difference between 55% and 97% of them resolving. The
+    # page announces its path in <link rel="EditURI">, but a url_mutation
+    # rewrites the URL without ever seeing the page. Each miss costs a request,
+    # since callers fetch every candidate.
     # The pipe in usprop stays unencoded: %7C is refused outright by some wikis.
     'MediaWiki API': {
         'url_hints': ('wikipedia.org', '/wiki/user:', '/user:'),
@@ -2867,23 +2871,23 @@ schemes = {
         'url_mutations': [
             {
                 # 60.5% of the wikis maigret knows keep api.php at the root
-                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
-                'to': 'https://{base}/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+                'from': r'https?://(?P<host>[^/?#]+)[^?#]*?/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{host}/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
             },
             {
                 # another 31% under /w
-                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
-                'to': 'https://{base}/w/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+                'from': r'https?://(?P<host>[^/?#]+)[^?#]*?/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{host}/w/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
             },
             {
                 # then /mediawiki
-                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
-                'to': 'https://{base}/mediawiki/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+                'from': r'https?://(?P<host>[^/?#]+)[^?#]*?/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{host}/mediawiki/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
             },
             {
                 # and /wiki — the four together cover 97.6% of them
-                'from': r'https?://(?P<base>[^?#]*?)/(?:wiki/)?User:(?P<username>[^/?#]+)',
-                'to': 'https://{base}/wiki/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
+                'from': r'https?://(?P<host>[^/?#]+)[^?#]*?/(?:wiki/)?User:(?P<username>[^/?#]+)',
+                'to': 'https://{host}/wiki/api.php?action=query&list=users&ususers={username}&usprop=editcount|registration|groups|gender&format=json',
             },
         ],
         'fields': {

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1817,3 +1817,23 @@ def test_discourse_html_profile():
     assert info.get('username') == 'hugovk'
     assert info.get('bio')
     assert 'user_avatar' in info.get('image', '')
+
+
+def test_mediawiki_api():
+    """MediaWiki API"""
+    # the /w/ candidate is the one Wikipedia answers; the root one 404s
+    url = [u for u, _ in mutate_url('https://en.wikipedia.org/wiki/User:Jimbo_Wales') if '/w/api.php' in u][0]
+    info = extract(parse(url)[0])
+
+    assert info.get('uid') == '24'
+    assert info.get('username') == 'Jimbo Wales'
+    assert info.get('created_at') == '2001-03-27T20:47:31Z'
+    assert 'founder' in info.get('groups', '')
+
+
+def test_mediawiki_user_page():
+    """MediaWiki user page"""
+    # what maigret reads without --enrich: the page it already fetches
+    info = extract(parse('https://wiki.openstreetmap.org/User:Leijurv')[0])
+
+    assert info.get('username') == 'Leijurv'

--- a/tests/test_socid_improvements.py
+++ b/tests/test_socid_improvements.py
@@ -829,8 +829,8 @@ def test_scratch_api_json():
     assert info.get('is_scratchteam') == 'False'
 
 
-def test_wikipedia_user_api_json():
-    """Wikipedia user API: extract user info from MediaWiki user query with editcount."""
+def test_mediawiki_api_json():
+    """MediaWiki API: extract user info from a users query with editcount."""
     body = json.dumps({
         "batchcomplete": "",
         "query": {
@@ -1435,6 +1435,35 @@ def test_patreon_rsc_deref_reads_hex_row_ids():
     assert _patreon_rsc_deref(rsc, '{"bio":"$undefined"}') == '{"bio":"$undefined"}'
 
     
+def test_mediawiki_mutation_offers_both_api_paths():
+    """api.php sits at the root on some wikis and under /w/ on others."""
+    from socid_extractor.main import mutate_url
+
+    def paths(url):
+        return [u.split('?')[0] for u, _ in mutate_url(url)]
+
+    # the shape maigret stores, with and without the /wiki/ subpath
+    assert paths('https://wiki.openstreetmap.org/User:Leijurv') == [
+        'https://wiki.openstreetmap.org/api.php', 'https://wiki.openstreetmap.org/w/api.php',
+        'https://wiki.openstreetmap.org/mediawiki/api.php', 'https://wiki.openstreetmap.org/wiki/api.php']
+    assert paths('https://imslp.org/wiki/User:Hfredrich416hk')[:2] == [
+        'https://imslp.org/api.php', 'https://imslp.org/w/api.php']
+    # a subpage of a user page is not the user
+    assert 'ususers=Jimbo_Wales&' in mutate_url('https://en.wikipedia.org/wiki/User:Jimbo_Wales/sandbox')[0][0]
+
+
+def test_mediawiki_user_page_needs_the_account_to_exist():
+    """wgRelevantUserName is missing on a user page nobody registered."""
+    page = ('<div class="mw-body-content">'
+            'RLCONF={"wgCanonicalNamespace":"User","wgRelevantUserName":"Leijurv"}</div>')
+    assert extract(page).get('username') == 'Leijurv'
+
+    # the page still renders for an unregistered name, just without the variable
+    missing = ('<div class="mw-body-content">'
+               'RLCONF={"wgCanonicalNamespace":"User","mw-userpage-userdoesnotexist":1}</div>')
+    assert extract(missing) == {}
+
+
 def test_no_flag_subset_shadows():
     """Detect scheme pairs where one's flags are a subset of another's.
 

--- a/tests/test_socid_improvements.py
+++ b/tests/test_socid_improvements.py
@@ -1448,6 +1448,9 @@ def test_mediawiki_mutation_offers_both_api_paths():
         'https://wiki.openstreetmap.org/mediawiki/api.php', 'https://wiki.openstreetmap.org/wiki/api.php']
     assert paths('https://imslp.org/wiki/User:Hfredrich416hk')[:2] == [
         'https://imslp.org/api.php', 'https://imslp.org/w/api.php']
+    # the page's own path says nothing about the API's: wiki.dolibarr.org serves
+    # the page under /index.php and the API at the root, and it is far from alone
+    assert paths('https://wiki.dolibarr.org/index.php/User:Eldy')[0] == 'https://wiki.dolibarr.org/api.php'
     # a subpage of a user page is not the user
     assert 'ususers=Jimbo_Wales&' in mutate_url('https://en.wikipedia.org/wiki/User:Jimbo_Wales/sandbox')[0][0]
 


### PR DESCRIPTION
Only the mutation was Wikipedia-specific — the users API JSON is what every MediaWiki answers. Generalised, it now covers the 180 wikis on that engine in maigret's database instead of one. `api.php` sits at the root on 60.5% of them and under `/w` on another 31%; four candidates cover 97.6%.

`MediaWiki user page` is new because the API half only pays off under `--enrich`. Without it maigret fetches the HTML, which the API scheme can't match, and 39 of 39 sampled sites extracted nothing. That page has no numeric id, only `wgRelevantUserName` — which on 14 wikis tested appeared for real accounts and never for unregistered names.
