### PR TITLE
Flarum: add extraction scheme for Flarum forums (#293)

### DIFF
--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -288,6 +288,55 @@ def _discourse_html_profile(page):
     return json.dumps({'username': username, 'bio': bio, 'image': image})
 
 
+def _flarum_api_user(payload):
+    """Extract the matching user object from a Flarum JSON:API response.
+
+    Flarum answers GET /api/users?filter[q]={name} with a JSON:API document.
+    Because filter[q] is a search, data can contain multiple users or none.
+    We match the exact username from the query URL in links, or return the
+    single user if only one was returned.
+    """
+    if not isinstance(payload, dict):
+        return {}
+
+    data = payload.get('data')
+    if isinstance(data, dict):
+        # Direct user object (e.g. GET /api/users/{id})
+        return data
+    if not isinstance(data, list) or not data:
+        return {}
+
+    # Try to extract the queried username from links.first or links.self
+    target = None
+    links = payload.get('links') or {}
+    for link_key in ('first', 'self'):
+        url_str = links.get(link_key, '')
+        if url_str:
+            import urllib.parse
+            parsed = urllib.parse.urlparse(url_str)
+            query = urllib.parse.parse_qs(parsed.query)
+            q_list = query.get('filter[q]') or query.get('filter%5Bq%5D') or query.get('q')
+            if q_list and q_list[0]:
+                target = q_list[0].strip()
+                break
+
+    if target:
+        target_lower = target.lower()
+        for item in data:
+            if isinstance(item, dict):
+                attrs = item.get('attributes') or {}
+                username = attrs.get('username') or ''
+                if username.lower() == target_lower:
+                    return item
+        return {}
+
+    # If no search query was detected in links and exactly one user was returned
+    if len(data) == 1 and isinstance(data[0], dict):
+        return data[0]
+
+    return {}
+
+
 def _fl_ld(soup, *keys):
     """Extract a nested value from FL.ru JSON-LD (application/ld+json)."""
     tag = soup.find('script', type='application/ld+json')
@@ -3585,6 +3634,28 @@ schemes = {
                 'to': 'https://{base}/u/{username}.json',
             },
         ],
+    },
+    'Flarum API': {
+        'flags': ['"joinTime"', '"discussionCount"'],
+        'regex': r'^(\{[\s\S]+\})$',
+        'extract_json': True,
+        'transforms': [
+            json.loads,
+            _flarum_api_user,
+            json.dumps,
+        ],
+        'fields': {
+            'uid': lambda x: str(x.get('id')) if x.get('id') is not None else None,
+            'username': lambda x: x.get('attributes', {}).get('username'),
+            'fullname': lambda x: x.get('attributes', {}).get('displayName') or None,
+            'image': lambda x: x.get('attributes', {}).get('avatarUrl') or None,
+            'created_at': lambda x: x.get('attributes', {}).get('joinTime'),
+            'latest_activity_at': lambda x: x.get('attributes', {}).get('lastSeenAt') or None,
+            'bio': lambda x: x.get('attributes', {}).get('bio') or None,
+            'posts_count': lambda x: x.get('attributes', {}).get('discussionCount'),
+            'comments_count': lambda x: x.get('attributes', {}).get('commentCount'),
+        },
+        'url_hints': ('/api/users',),
     },
     'Snapchat': {
         'flags': ['__NEXT_DATA__', '"userProfile":'],

--- a/tests/test_extended_schemes.py
+++ b/tests/test_extended_schemes.py
@@ -141,3 +141,101 @@ def test_visnesscard_api_json():
     assert 'icon.png' in info.get('image', '')
     assert info.get('views_count') == '30'
     assert info.get('created_at') == '2021-04-08T20:24:43.823'
+
+
+def test_flarum_api_single_user():
+    """Flarum API: extract single user details."""
+    body = json.dumps({
+        "links": {
+            "first": "https://discuss.flarum.org/api/users?filter%5Bq%5D=luceos"
+        },
+        "data": [
+            {
+                "type": "users",
+                "id": "1",
+                "attributes": {
+                    "username": "luceos",
+                    "displayName": "Luceos Dev",
+                    "avatarUrl": "https://discuss.flarum.org/assets/avatars/1.png",
+                    "bio": "Flarum core team member",
+                    "joinTime": "2015-08-20T10:00:00+00:00",
+                    "lastSeenAt": "2026-03-01T12:00:00+00:00",
+                    "discussionCount": 150,
+                    "commentCount": 3500,
+                },
+            }
+        ]
+    })
+    info = extract(body)
+    assert info.get('uid') == '1'
+    assert info.get('username') == 'luceos'
+    assert info.get('fullname') == 'Luceos Dev'
+    assert info.get('image') == 'https://discuss.flarum.org/assets/avatars/1.png'
+    assert info.get('bio') == 'Flarum core team member'
+    assert info.get('created_at') == '2015-08-20T10:00:00+00:00'
+    assert info.get('latest_activity_at') == '2026-03-01T12:00:00+00:00'
+    assert info.get('posts_count') == '150'
+    assert info.get('comments_count') == '3500'
+
+
+def test_flarum_api_multi_user_exact_match():
+    """Flarum API: match queried username among multiple search results."""
+    body = json.dumps({
+        "links": {
+            "first": "https://community.nodebb.org/api/users?filter[q]=rammiro"
+        },
+        "data": [
+            {
+                "type": "users",
+                "id": "10",
+                "attributes": {
+                    "username": "rammiro_fan",
+                    "displayName": "Fan of Rammiro",
+                    "avatarUrl": None,
+                    "bio": None,
+                    "joinTime": "2021-01-01T00:00:00+00:00",
+                    "lastSeenAt": None,
+                    "discussionCount": 2,
+                    "commentCount": 10,
+                },
+            },
+            {
+                "type": "users",
+                "id": "42",
+                "attributes": {
+                    "username": "rammiro",
+                    "displayName": "Rammiro",
+                    "avatarUrl": "https://avatar.example.com/42.jpg",
+                    "bio": "Active contributor",
+                    "joinTime": "2019-05-15T08:30:00+00:00",
+                    "lastSeenAt": "2026-02-28T18:00:00+00:00",
+                    "discussionCount": 45,
+                    "commentCount": 620,
+                },
+            },
+        ]
+    })
+    info = extract(body)
+    assert info.get('uid') == '42'
+    assert info.get('username') == 'rammiro'
+    assert info.get('fullname') == 'Rammiro'
+    assert info.get('image') == 'https://avatar.example.com/42.jpg'
+    assert info.get('bio') == 'Active contributor'
+    assert info.get('created_at') == '2019-05-15T08:30:00+00:00'
+    assert info.get('latest_activity_at') == '2026-02-28T18:00:00+00:00'
+    assert info.get('posts_count') == '45'
+    assert info.get('comments_count') == '620'
+
+
+def test_flarum_api_forbidden_error():
+    """Flarum API: 403 permission denied returns empty dict."""
+    body = json.dumps({
+        "errors": [
+            {
+                "status": "403",
+                "code": "permission_denied"
+            }
+        ]
+    })
+    info = extract(body)
+    assert info == {}


### PR DESCRIPTION
Closes #293

### Summary
Adds an extraction scheme for Flarum forum instances (`/api/users?filter[q]={name}`).

### Changes
- **`socid_extractor/schemes.py`**:
  - Added `_flarum_api_user` transform function: parses queried username from `links.first` / `links.self` (`filter[q]`), performs case-insensitive exact matching against `username` in `data` items (falling back to single item if query is missing and only 1 user exists), and safely handles empty/invalid payloads.
  - Added `'Flarum API'` scheme definition:
    - Flags: `'"joinTime"'`, `'"discussionCount"'`
    - Transforms: `[json.loads, _flarum_api_user, json.dumps]`
    - Fields extracted: `uid`, `username`, `fullname` (`displayName`), `image` (`avatarUrl`), `created_at` (`joinTime`), `latest_activity_at` (`lastSeenAt`), `bio`, `posts_count` (`discussionCount`), `comments_count` (`commentCount`).
    - URL hint: `('/api/users',)`
- **`tests/test_extended_schemes.py`**:
  - Added `test_flarum_api_single_user`: verifies extraction of all fields from a Flarum JSON:API response.
  - Added `test_flarum_api_multi_user_exact_match`: verifies exact matching by query among multiple user results.
  - Added `test_flarum_api_forbidden_error`: verifies that 403 / permission denied error responses safely return `{}` without error.
