### PR TITLE
feat: extract vBulletin profile identifiers

### DIFF
--- a/socid_extractor/schemes.py
+++ b/socid_extractor/schemes.py
@@ -2,7 +2,7 @@ from dateutil.parser import parse as parse_datetime_str
 import html
 import json
 import itertools
-from urllib.parse import unquote
+from urllib.parse import parse_qs, unquote, urlparse
 
 from .utils import *
 
@@ -177,6 +177,58 @@ def _faceit_streaming_links(profile):
         if handle:
             links[platform.removesuffix('_id')] = handle
     return links
+
+
+def _vbulletin_id_from_href(href):
+    """Return a vBulletin profile id encoded in a profile/search link."""
+    parsed = urlparse(href)
+    page = parsed.path.rsplit('/', 1)[-1]
+    query = parse_qs(parsed.query)
+    if page in ('member.php', 'profile.php'):
+        return (query.get('u') or [None])[0]
+    if page == 'search.php' and (query.get('do') or [None])[0] == 'finduser':
+        return (query.get('u') or query.get('userid') or [None])[0]
+    return None
+
+
+def _vbulletin_uid(soup):
+    """Extract a profile id without treating thread participants as one profile."""
+    relpath = soup.find(string=lambda value: value and 'RELPATH' in value)
+    if relpath:
+        match = re.search(r'RELPATH\s*=\s*["\']member\.php\?u=(\d+)', relpath)
+        if match:
+            return match.group(1)
+
+    header = soup.find(id='memberinfoheader') or soup.find(id='avatar')
+    if header:
+        ids = {
+            _vbulletin_id_from_href(a.get('href', ''))
+            for a in header.find_all('a', href=True)
+        }
+        ids.discard(None)
+        if len(ids) == 1:
+            return ids.pop()
+
+    stats = soup.find(id='stats')
+    links = (
+        stats.find_all('a', href=True)
+        if stats else soup.find_all('a', href=True)
+    )
+    ids = {_vbulletin_id_from_href(a.get('href', '')) for a in links}
+    ids.discard(None)
+    return ids.pop() if len(ids) == 1 else None
+
+
+def _vbulletin_username(soup):
+    member_username = soup.find(class_='member_username')
+    if member_username:
+        return member_username.get_text(' ', strip=True)
+
+    username_box = soup.find(id='username_box')
+    heading = username_box.find('h1') if username_box else None
+    if heading:
+        return heading.get_text(' ', strip=True)
+    return None
 
 
 def _yt_redirect_urls(data):
@@ -2040,11 +2092,11 @@ schemes = {
         },
     },
     'vBulletinEngine': {
-        'flags': ['vBulletin.register_control'],
+        'flags': ['vBulletin'],
         'bs': True,
         'fields': {
-            'status': lambda x: x.find('span', {'class': 'online-status'}).findAll('span')[1].text,
-            'country': lambda x: (x.find('span', {'class': 'sprite_flags'}) or {}).get('title'),
+            'uid': _vbulletin_uid,
+            'username': _vbulletin_username,
             'image': lambda x: x.find('span', {'class': 'avatarcontainer'}).find('img').get('src'),
         }
     },

--- a/tests/test_extended_schemes.py
+++ b/tests/test_extended_schemes.py
@@ -141,3 +141,46 @@ def test_visnesscard_api_json():
     assert 'icon.png' in info.get('image', '')
     assert info.get('views_count') == '30'
     assert info.get('created_at') == '2021-04-08T20:24:43.823'
+
+
+def test_vbulletin_v4_profile_identifiers():
+    """vBulletin 4 profile pages expose id in RELPATH and username in the header."""
+    html = '''
+    <meta name="generator" content="vBulletin 4.2.5">
+    <script>var RELPATH = "member.php?u=144363";</script>
+    <div id="memberinfoheader">
+      <a class="avatar" href="member.php?u=144363&amp;s=session">
+        <span class="avatarcontainer"><img src="avatar.png"></span>
+      </a>
+      <div id="userinfo"><span class="member_username">Adam</span></div>
+    </div>
+    <a class="username" href="member.php?u=60945">visitor</a>
+    '''
+    info = extract(html)
+    assert info.get('uid') == '144363'
+    assert info.get('username') == 'Adam'
+    assert info.get('image') == 'avatar.png'
+
+
+def test_vbulletin_v3_profile_identifiers():
+    """vBulletin 3 profile pages expose the id in finduser links."""
+    html = '''
+    <meta name="generator" content="vBulletin 3.8.8">
+    <div id="username_box"><h1>Alex <img src="offline.gif"></h1></div>
+    <div id="stats"><a href="search.php?do=finduser&amp;u=106">Find posts</a>
+      <a href="search.php?do=finduser&amp;u=106&amp;starteronly=1">Find threads</a></div>
+    '''
+    info = extract(html)
+    assert info.get('uid') == '106'
+    assert info.get('username') == 'Alex'
+
+
+def test_vbulletin_thread_with_multiple_participants_has_no_profile_id():
+    """A thread with several participant ids must not identify one as the profile."""
+    html = '''
+    <meta name="generator" content="vBulletin 4.2.5">
+    <a href="search.php?do=finduser&amp;u=106">Alex</a>
+    <a href="search.php?do=finduser&amp;u=2835">Snejana191</a>
+    '''
+    info = extract(html)
+    assert 'uid' not in info


### PR DESCRIPTION
Closes #294

The vBulletin scheme now returns the profile identifier and username for both markup variants described in the issue:

- vBulletin 4 reads the id from the profile page's RELPATH or member header.
- vBulletin 3 reads the id from the profile's finduser links.
- Thread pages with multiple participant ids return no uid instead of guessing.
- The two unused status and country fields were removed; avatar extraction stays in place.

Tests:

- `python -m pytest tests/test_extended_schemes.py -q` (8 passed)
- Checked the vBulletin 4 and vBulletin 3 example profile pages from the issue locally.

The offline fixtures cover both versions and the multi-participant guard, without live requests or cookies.