### PR TITLE
Skip the 500px test while their API is migrating

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -53,7 +53,7 @@
 48 | D3.ru | [d3](https://github.com/soxoj/socid-extractor/search?q=test_d3) | requests from GitHub Actions CI servers are blocked |
 49 | Gitlab |  |  |
 50 | 500px userByUsername API |  |  |
-51 | 500px GraphQL API | [500px](https://github.com/soxoj/socid-extractor/search?q=test_500px) |  |
+51 | 500px GraphQL API | [500px](https://github.com/soxoj/socid-extractor/search?q=test_500px) | down |
 52 | Google Document API | [google_documents](https://github.com/soxoj/socid-extractor/search?q=test_google_documents) |  |
 53 | Google Document |  |  |
 54 | Google Maps contributions |  |  |
@@ -268,4 +268,4 @@
 263 | ReverbNation artist |  |  |
 264 | XenForo | [xenforo](https://github.com/soxoj/socid-extractor/search?q=test_xenforo) |  |
 
-The table has been updated at 2026-09-07 22:00:38.122362 UTC
+The table has been updated at 2026-09-12 12:05:34.166822 UTC

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -419,7 +419,8 @@ def test_behance():
     assert 'appreciations' in info
 
 
-def test_500px():
+@pytest.mark.skip(reason="down")
+def test_500px():  # Broken. API answers with error 1503, a platform migration.
     """500px GraphQL API"""
     mutated_url = mutate_url('https://500px.com/p/the-maksimov')
     url, add_headers = mutated_url[0]


### PR DESCRIPTION
500px is migrating: their GraphQL answers HTTP 200 with error 1503 and "a fresh version of 500px is rolling out" instead of data, and the ETA in that message (Sep 10, 12:00 UTC) has already passed. The profile page is an empty SPA shell too, so there is nothing to parse anywhere.

Master has been red since Sep 7 because of it, and it takes down every contributor PR — #295 and #296 are green apart from this one test.
